### PR TITLE
Logging init fix for issue #13

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -66,3 +66,4 @@ include README.md
 include *.py
 global-include src/fparser/tests/*.py
 recursive-include doc *.py *.rst Makefile
+recursive-include src *.config

--- a/src/fparser/__init__.py
+++ b/src/fparser/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2017 Science and Technology Facilities Council
+# Original work Copyright (c) 1999-2008 Pearu Peterson
 
 # All rights reserved.
 
@@ -31,3 +32,45 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# --------------------------------------------------------------------
+
+# The original software (in the f2py project) was distributed under
+# the following license:
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+#   a. Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+#   b. Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#   c. Neither the name of the F2PY project nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+
+# First version by: Pearu Peterson <pearu@cens.ioc.ee>
+# First created: Oct 2006
+
+import os
+# Make logging available within the fparser namespace
+import logging, logging.config
+
+# Default logging configuration file
+_DEFAULT_LOG_CONFIG_PATH = os.path.join(os.path.dirname(__file__),
+                                        'log.config')
+# Setup loggers
+logging.config.fileConfig(_DEFAULT_LOG_CONFIG_PATH)


### PR DESCRIPTION
Puts back the necessary code to initialise logging within the fparser package.
Required for PSyclone to successfully use the package.