### PR TITLE
Allow for Procedure declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Original code by Pearu Peterson.
 Modifications by Andrew Porter and Rupert Ford of the Science
 and Technology Facilities Council, UK.
 
+20/06/2017 issue #30 pr #31 Extend fparser1 to support
+ 	   Fortran2003 procedure declarations
+
+
 ## Release 0.0.4 ##
 
 11/05/2017 pypi configuration was incorrect so 0.0.3 was

--- a/doc/fparser.rst
+++ b/doc/fparser.rst
@@ -168,12 +168,16 @@ being added on an as-required basis and currently consists of:
 
   ::
 
-       call an_array(3)%a_proc(an_arg)
+     call an_array(3)%a_proc(an_arg)
 * Declaration of a CLASS variable (Fortran 2003), e.g.
   ::
 
      class(my_class) var
+* Declaration of a procedure (Fortran 2003), e.g.
+  ::
 
+     procedure(interface_name) :: proc
+     
 Reference
 ^^^^^^^^^
 

--- a/src/fparser/block_statements.py
+++ b/src/fparser/block_statements.py
@@ -1364,9 +1364,11 @@ internal_subprogram = [Function, Subroutine]
 
 internal_subprogram_part = [Contains, ] + internal_subprogram
 
+# In Fortran2003 we can have a Procedure declaration. We therefore
+# include SpecificBinding as a valid declaration construct.
 declaration_construct = [TypeDecl, Entry, Enum, Format, Interface,
-    Parameter, ModuleProcedure,] + specification_stmt + \
-    type_declaration_stmt
+                         Parameter, ModuleProcedure, SpecificBinding] + \
+    specification_stmt + type_declaration_stmt
 # stmt-function-stmt
 
 implicit_part = [ Implicit, Parameter, Format, Entry ]

--- a/src/fparser/block_statements.py
+++ b/src/fparser/block_statements.py
@@ -688,7 +688,10 @@ class SubProgramStatement(BeginStatement, ProgramBlock,
             elif isinstance(stmt, self.end_stmt_cls):
                 continue
             else:
-                stmt.analyze()
+                if hasattr(stmt, "analyze"):
+                    stmt.analyze()
+                else:
+                    raise AnalyzeError('Failed to parse: {0}'.format(str(stmt)))
 
         if content:
             logger.info('Not analyzed content: %s' % content)

--- a/src/fparser/tests/test_functional.py
+++ b/src/fparser/tests/test_functional.py
@@ -1,35 +1,58 @@
+# Copyright (c) 2017 Science and Technology Facilities Council
+
+# All rights reserved.
+
+# Modifications made as part of the fparser project are distributed
+# under the following license:
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+''' Module containing functional tests - i.e. tests of specific functionality
+    within the context of parsing a piece of compilable Fortran '''
+
+
 def test_procedure_interface():
-    ''' Functional test that parser copes with a procedure declaration in
+    ''' Test that parser copes with a procedure declaration in
     a subroutine '''
     from fparser import api
-    source_str = '''  subroutine divergence_diagnostic_alg(u, t, mesh_id)
-    use dg_matrix_vector_kernel_mod, only: dg_matrix_vector_kernel_type
-    use runtime_constants_mod,       only: get_mass_matrix, &
-                                           get_div, &
-                                           w3inv_id
-    use operator_mod,                only: operator_type
+    source_str = '''  subroutine proc_interface_test()
     use field_mod,                   only: field_type, write_interface
     use fs_continuity_mod,           only: W3
-    use psykal_lite_mod,             only: invoke_inner_prod
+    use io_mod,                      only: write_field
     implicit none
-    type(field_type), intent(in) :: u
-    integer(i_def),   intent(in) :: t, mesh_id
-
-    type(field_type)             :: divergence, div_u
-    type(operator_type), pointer :: div => null(), m3_inv => null()
-    real(r_def)                  :: l2
-
+    type(field_type)                      :: divergence
     procedure (write_interface), pointer  :: tmp_ptr
 
-    divergence =  field_type( vector_space = &
-            function_space_collection%get_fs(mesh_id,element_order, W3) )
-    div_u = field_type( vector_space=function_space_collection%get_fs(mesh_id,&
-                        element_order, W3) )
-    div    => get_div()
-    m3_inv => get_mass_matrix(w3inv_id)
-    call invoke( dg_matrix_vector_kernel_type( div_u, u, div) )
-
-  end subroutine divergence_diagnostic_alg
+    divergence = field_type( vector_space = &
+                    function_space_collection%get_fs(0, 0, W3) )
+    tmp_ptr => write_field
+    call divergence%set_write_field_behaviour(write_field)
+  end subroutine proc_interface_test
 '''
     tree = api.parse(source_str, isfree=True, isstrict=False,
                      ignore_comments=False)

--- a/src/fparser/tests/test_functional.py
+++ b/src/fparser/tests/test_functional.py
@@ -11,7 +11,7 @@ def test_procedure_interface():
     use field_mod,                   only: field_type, write_interface
     use fs_continuity_mod,           only: W3
     use psykal_lite_mod,             only: invoke_inner_prod
-    implicit none 
+    implicit none
     type(field_type), intent(in) :: u
     integer(i_def),   intent(in) :: t, mesh_id
 
@@ -21,8 +21,10 @@ def test_procedure_interface():
 
     procedure (write_interface), pointer  :: tmp_ptr
 
-    divergence =  field_type( vector_space = function_space_collection%get_fs(mesh_id,element_order, W3) )
-    div_u      =  field_type( vector_space = function_space_collection%get_fs(mesh_id,element_order, W3) )
+    divergence =  field_type( vector_space = &
+            function_space_collection%get_fs(mesh_id,element_order, W3) )
+    div_u = field_type( vector_space=function_space_collection%get_fs(mesh_id,&
+                        element_order, W3) )
     div    => get_div()
     m3_inv => get_mass_matrix(w3inv_id)
     call invoke( dg_matrix_vector_kernel_type( div_u, u, div) )
@@ -31,6 +33,5 @@ def test_procedure_interface():
 '''
     tree = api.parse(source_str, isfree=True, isstrict=False,
                      ignore_comments=False)
-    gen_code =  str(tree)
+    gen_code = str(tree)
     assert "PROCEDURE (write_interface) , POINTER :: tmp_ptr" in gen_code
-

--- a/src/fparser/tests/test_functional.py
+++ b/src/fparser/tests/test_functional.py
@@ -1,5 +1,6 @@
 def test_procedure_interface():
-    ''' Functional test that parser copes with a procedure declaration '''
+    ''' Functional test that parser copes with a procedure declaration in
+    a subroutine '''
     from fparser import api
     source_str = '''  subroutine divergence_diagnostic_alg(u, t, mesh_id)
     use dg_matrix_vector_kernel_mod, only: dg_matrix_vector_kernel_type
@@ -10,10 +11,6 @@ def test_procedure_interface():
     use field_mod,                   only: field_type, write_interface
     use fs_continuity_mod,           only: W3
     use psykal_lite_mod,             only: invoke_inner_prod
-    use log_mod,                     only: log_event,         &
-                                           log_scratch_space, &
-                                           LOG_LEVEL_INFO
-
     implicit none 
     type(field_type), intent(in) :: u
     integer(i_def),   intent(in) :: t, mesh_id
@@ -22,8 +19,7 @@ def test_procedure_interface():
     type(operator_type), pointer :: div => null(), m3_inv => null()
     real(r_def)                  :: l2
 
-    !procedure (write_interface), pointer  :: tmp_ptr
-    procedure (a) :: tmp_ptr
+    procedure (write_interface), pointer  :: tmp_ptr
 
     divergence =  field_type( vector_space = function_space_collection%get_fs(mesh_id,element_order, W3) )
     div_u      =  field_type( vector_space = function_space_collection%get_fs(mesh_id,element_order, W3) )
@@ -35,6 +31,6 @@ def test_procedure_interface():
 '''
     tree = api.parse(source_str, isfree=True, isstrict=False,
                      ignore_comments=False)
-    print str(tree)
-    assert 0
+    gen_code =  str(tree)
+    assert "PROCEDURE (write_interface) , POINTER :: tmp_ptr" in gen_code
 

--- a/src/fparser/tests/test_functional.py
+++ b/src/fparser/tests/test_functional.py
@@ -1,0 +1,40 @@
+def test_procedure_interface():
+    ''' Functional test that parser copes with a procedure declaration '''
+    from fparser import api
+    source_str = '''  subroutine divergence_diagnostic_alg(u, t, mesh_id)
+    use dg_matrix_vector_kernel_mod, only: dg_matrix_vector_kernel_type
+    use runtime_constants_mod,       only: get_mass_matrix, &
+                                           get_div, &
+                                           w3inv_id
+    use operator_mod,                only: operator_type
+    use field_mod,                   only: field_type, write_interface
+    use fs_continuity_mod,           only: W3
+    use psykal_lite_mod,             only: invoke_inner_prod
+    use log_mod,                     only: log_event,         &
+                                           log_scratch_space, &
+                                           LOG_LEVEL_INFO
+
+    implicit none 
+    type(field_type), intent(in) :: u
+    integer(i_def),   intent(in) :: t, mesh_id
+
+    type(field_type)             :: divergence, div_u
+    type(operator_type), pointer :: div => null(), m3_inv => null()
+    real(r_def)                  :: l2
+
+    !procedure (write_interface), pointer  :: tmp_ptr
+    procedure (a) :: tmp_ptr
+
+    divergence =  field_type( vector_space = function_space_collection%get_fs(mesh_id,element_order, W3) )
+    div_u      =  field_type( vector_space = function_space_collection%get_fs(mesh_id,element_order, W3) )
+    div    => get_div()
+    m3_inv => get_mass_matrix(w3inv_id)
+    call invoke( dg_matrix_vector_kernel_type( div_u, u, div) )
+
+  end subroutine divergence_diagnostic_alg
+'''
+    tree = api.parse(source_str, isfree=True, isstrict=False,
+                     ignore_comments=False)
+    print str(tree)
+    assert 0
+


### PR DESCRIPTION
This PR is for work done in #31. It simply makes SpecificBinding a valid declaration entity and add a functional test for this. I've also taken the opportunity to make fparser print a useful message if it fails to parse something. All tests pass or xfail. (All PSyclone tests pass or xfail with this version too.)