### PR TITLE
Fix for namelist/format specifier confusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Original code by Pearu Peterson.
 Modifications by Andrew Porter and Rupert Ford of the Science
 and Technology Facilities Council, UK.
 
+06/09/2017 issue #34 pr #37 Fix a format statement parsing
+	   bug in fparser2
+
 ## Release 0.0.5 (20/06/2017) ##
 
 20/06/2017 issue #30 pr #31 Extend fparser1 to support

--- a/src/fparser/Fortran2003.py
+++ b/src/fparser/Fortran2003.py
@@ -5453,7 +5453,7 @@ items : (Io_Control_Spec_List, Format, Input_Item_List)
             return
         char = line[0].upper()
         # No parentheses therefore first argument must be a format
-        # specifier (either a string or a line/lable number
+        # specifier (either a string or a line/label number
         if 'A' <= char <= 'Z' or char == '_':
             return
         line, repmap = string_replace_map(line.lstrip())

--- a/src/fparser/Fortran2003.py
+++ b/src/fparser/Fortran2003.py
@@ -536,13 +536,10 @@ class KeywordValueBase(Base):
             return
         if isinstance(lhs_cls, (list, tuple)):
             for s in lhs_cls:
-                try:
-                    obj = KeywordValueBase.match(s, rhs_cls, string,
-                                                 require_lhs=require_lhs,
-                                                 upper_lhs=upper_lhs)
-                except NoMatchError:
-                    obj = None
-                if obj is not None:
+                obj = KeywordValueBase.match(s, rhs_cls, string,
+                                             require_lhs=require_lhs,
+                                             upper_lhs=upper_lhs)
+                if obj:
                     return obj
             return obj
         if "=" in string:

--- a/src/fparser/Fortran2003.py
+++ b/src/fparser/Fortran2003.py
@@ -96,6 +96,7 @@ def show_result(func):
         return r
     return new_func
 
+
 class Base(object):
     """ Base class for Fortran 2003 syntax rules.
 
@@ -523,37 +524,51 @@ class SeparatorBase(Base):
             s += ' %s' % (self.items[1])
         return s
 
+
 class KeywordValueBase(Base):
     """
 ::
     <keyword-value-base> = [ <lhs> = ] <rhs>
     """
-    def match(lhs_cls, rhs_cls, string, require_lhs = True, upper_lhs = False):
-        if require_lhs and '=' not in string: return
+    @staticmethod
+    def match(lhs_cls, rhs_cls, string, require_lhs=True, upper_lhs=False):
+        if require_lhs and '=' not in string:
+            return
         if isinstance(lhs_cls, (list, tuple)):
             for s in lhs_cls:
                 try:
-                    obj = KeywordValueBase.match(s, rhs_cls, string, require_lhs=require_lhs, upper_lhs=upper_lhs)
+                    obj = KeywordValueBase.match(s, rhs_cls, string,
+                                                 require_lhs=require_lhs,
+                                                 upper_lhs=upper_lhs)
                 except NoMatchError:
                     obj = None
-                if obj is not None: return obj
+                if obj is not None:
+                    return obj
             return obj
-        lhs,rhs = string.split('=',1)
-        lhs = lhs.rstrip()
+        if "=" in string:
+            lhs, rhs = string.split('=', 1)
+            lhs = lhs.rstrip()
+        else:
+            lhs = None
+            rhs = string.rstrip()
         rhs = rhs.lstrip()
-        if not rhs: return
+        if not rhs:
+            return
         if not lhs:
-            if require_lhs: return
+            if require_lhs:
+                return
             return None, rhs_cls(rhs)
         if isinstance(lhs_cls, str):
             if upper_lhs:
                 lhs = lhs.upper()
-            if lhs_cls!=lhs: return
+            if lhs_cls != lhs:
+                return
             return lhs, rhs_cls(rhs)
-        return lhs_cls(lhs),rhs_cls(rhs)
-    match = staticmethod(match)
+        return lhs_cls(lhs), rhs_cls(rhs)
+
     def tostr(self):
-        if self.items[0] is None: return str(self.items[1])
+        if self.items[0] is None:
+            return str(self.items[1])
         return '%s = %s' % tuple(self.items)
 
 class BracketBase(Base):
@@ -5407,6 +5422,7 @@ class Close_Spec(KeywordValueBase): # R909
         return 'UNIT', File_Unit_Number(string)
     match = staticmethod(match)
 
+
 class Read_Stmt(StmtBase): # R910
     """
 :F03R:`910`::
@@ -5421,30 +5437,38 @@ items : (Io_Control_Spec_List, Format, Input_Item_List)
     use_names = ['Io_Control_Spec_List', 'Input_Item_List', 'Format']
     @staticmethod
     def match(string):
-        if string[:4].upper()!='READ': return
+        if string[:4].upper() != 'READ':
+            return
         line = string[4:].lstrip()
         if line.startswith('('):
             line, repmap = string_replace_map(line)
-            i = line.find(')')
-            if i==-1: return
-            l = line[1:i].strip()
-            if not l: return
-            if i==len(line)-1:
-                return Io_Control_Spec_List(repmap(l)),None,None
-            return Io_Control_Spec_List(repmap(l)), None, Input_Item_List(repmap(line[i+1:].lstrip()))
-        if not line: return
+            idx = line.find(')')
+            if idx == -1:
+                return
+            l = line[1:idx].strip()
+            if not l:
+                return
+            if idx == len(line) - 1:
+                return Io_Control_Spec_List(repmap(l)), None, None
+            return Io_Control_Spec_List(repmap(l)), None, \
+                Input_Item_List(repmap(line[idx+1:].lstrip()))
+        if not line:
+            return
         c = line[0].upper()
-        if 'A'<=c<='Z' or c=='_' or '0'<=c<='9': return
+        if 'A'<=c<='Z' or c=='_' or '0'<=c<='9':
+            return
         line, repmap = string_replace_map(line.lstrip())
         i = line.find(',')
-        if i==-1: return Format(repmap(line)),None,None
+        if i == -1:
+            return Format(repmap(line)), None, None
         l = repmap(line[i+1:].lstrip())
-        if not l: return
+        if not l:
+            return
         return None, Format(repmap(line[:i].rstrip())), Output_Item_List(l)
     
     def tostr(self):
         if self.items[0] is not None:
-            assert self.items[1] is None,`self.items`
+            assert self.items[1] is None, `self.items`
             if self.items[2] is None:
                 return 'READ(%s)' % (self.items[0])
             return 'READ(%s) %s' % (self.items[0], self.items[2])
@@ -5506,9 +5530,11 @@ items : (Format, Output_Item_List)
         if not l: return
         return Format(repmap(line[:i].rstrip())), Output_Item_List(l)
     match = staticmethod(match)
+
     def tostr(self):
         if self.items[1] is None: return 'PRINT %s' % (self.items[0])
         return 'PRINT %s, %s' % tuple(self.items)
+
 
 class Io_Control_Spec_List(SequenceBase): # R913-list
     """
@@ -5516,32 +5542,41 @@ class Io_Control_Spec_List(SequenceBase): # R913-list
     """
     subclass_names = []
     use_names = ['Io_Control_Spec']
+    @staticmethod
     def match(string):
         line, repmap = string_replace_map(string)
         splitted = line.split(',')
-        if not splitted: return
+        if not splitted:
+            return
         lst = []
-        for i in range(len(splitted)):
-            p = splitted[i].strip()
-            if i==0:
-                if '=' not in p: p = 'UNIT=%s' % (repmap(p))
-                else: p = repmap(p)
-            elif i==1:
-                if '=' not in p:
-                    p = repmap(p)
-                    try:
-                        f = Format(p)
-                        # todo: make sure that f is char-expr, if not, raise NoMatchError
-                        p = 'FMT=%s' % (Format(p))
-                    except NoMatchError:
-                        p = 'NML=%s' % (Namelist_Group_Name(p))
-                else:
-                    p = repmap(p)
+        unit_is_positional = False
+        for idx in range(len(splitted)):
+            spec = splitted[idx].strip()
+            spec = repmap(spec)
+            if idx == 0 and "=" not in spec:
+                # Must be a unit number. However, we do not prepend "UNIT="
+                # to it in case the following Io_Control_Spec is positional
+                # (and therefore either a Format or Namelist spec).
+                lst.append(Io_Control_Spec(spec))
+                unit_is_positional = True
+            elif idx == 1 and "=" not in spec:
+                if not unit_is_positional:
+                    # Cannot have a positional argument following a
+                    # named argument
+                    return
+                # Without knowing the type of the variable named in spec
+                # we have no way of knowing whether this is a format or
+                # a namelist specifier. However, if it is a character
+                # constant or "*" then it must be a Format spec and we can
+                # prepend "FMT=" to it.
+                spec =  spec.lstrip().rstrip()
+                if Char_Literal_Constant.match(spec) or \
+                   StringBase.match("*", spec):
+                    spec = "FMT={0}".format(spec)
+                lst.append(Io_Control_Spec(spec))
             else:
-                p = repmap(p)
-            lst.append(Io_Control_Spec(p))
+                lst.append(Io_Control_Spec(spec))
         return ',', tuple(lst)
-    match = staticmethod(match)
 
 class Io_Control_Spec(KeywordValueBase): # R913
     """
@@ -5567,28 +5602,42 @@ class Io_Control_Spec(KeywordValueBase): # R913
                         | SIZE = <scalar-int-variable>
     """
     subclass_names = []
-    use_names = ['Io_Unit', 'Format', 'Namelist_Group_Name', 'Scalar_Default_Char_Expr',
-                 'Scalar_Char_Initialization_Expr', 'Label', 'Scalar_Int_Variable',
+    use_names = ['Io_Unit', 'Format', 'Namelist_Group_Name',
+                 'Scalar_Default_Char_Expr',
+                 'Scalar_Char_Initialization_Expr', 'Label',
+                 'Scalar_Int_Variable',
                  'Iomsg_Variable', 'Scalar_Int_Expr']
+    @staticmethod
     def match(string):
-        for (k,v) in [\
-            (['ADVANCE', 'BLANK', 'DECIMAL', 'DELIM', 'PAD', 'ROUND', 'SIGN'], Scalar_Default_Char_Expr),
+        for (k, v) in [\
+            ('UNIT', Io_Unit),
+            ('FMT', Format),
+            ('NML', Namelist_Group_Name)]:
+            try:
+                obj = KeywordValueBase.match(k, v, string,
+                                             require_lhs=False,
+                                             upper_lhs=True)
+            except NoMatchError:
+                obj = None
+            if obj is not None:
+                return obj
+
+        for (k, v) in [\
+            (['ADVANCE', 'BLANK', 'DECIMAL', 'DELIM', 'PAD', 'ROUND', 'SIGN'],
+             Scalar_Default_Char_Expr),
             ('ASYNCHRONOUS', Scalar_Char_Initialization_Expr),
             (['END','EOR','ERR'], Label),
             (['ID','IOSTAT','SIZE'], Scalar_Int_Variable),
             ('IOMSG', Iomsg_Variable),
-            (['POS', 'REC'], Scalar_Int_Expr),
-            ('UNIT', Io_Unit),
-            ('FMT', Format),
-            ('NML', Namelist_Group_Name)
-            ]:
+            (['POS', 'REC'], Scalar_Int_Expr)]:
             try:
-                obj = KeywordValueBase.match(k, v, string, upper_lhs = True)
+                obj = KeywordValueBase.match(k, v, string, upper_lhs=True)
             except NoMatchError:
                 obj = None
-            if obj is not None: return obj
+            if obj is not None:
+                return obj
         return
-    match = staticmethod(match)
+
 
 class Format(StringBase): # R914
     """

--- a/src/fparser/Fortran2003.py
+++ b/src/fparser/Fortran2003.py
@@ -5548,8 +5548,6 @@ class Io_Control_Spec_List(SequenceBase): # R913-list
     def match(string):
         line, repmap = string_replace_map(string)
         splitted = line.split(',')
-        if not splitted:
-            return
         lst = []
         unit_is_positional = False
         for idx in range(len(splitted)):
@@ -5615,13 +5613,10 @@ class Io_Control_Spec(KeywordValueBase): # R913
             ('UNIT', Io_Unit),
             ('FMT', Format),
             ('NML', Namelist_Group_Name)]:
-            try:
-                obj = KeywordValueBase.match(k, v, string,
-                                             require_lhs=False,
-                                             upper_lhs=True)
-            except NoMatchError:
-                obj = None
-            if obj is not None:
+            obj = KeywordValueBase.match(k, v, string,
+                                         require_lhs=False,
+                                         upper_lhs=True)
+            if obj:
                 return obj
 
         for (k, v) in [\
@@ -5632,11 +5627,8 @@ class Io_Control_Spec(KeywordValueBase): # R913
             (['ID','IOSTAT','SIZE'], Scalar_Int_Variable),
             ('IOMSG', Iomsg_Variable),
             (['POS', 'REC'], Scalar_Int_Expr)]:
-            try:
-                obj = KeywordValueBase.match(k, v, string, upper_lhs=True)
-            except NoMatchError:
-                obj = None
-            if obj is not None:
+            obj = KeywordValueBase.match(k, v, string, upper_lhs=True)
+            if obj:
                 return obj
         return
 

--- a/src/fparser/Fortran2003.py
+++ b/src/fparser/Fortran2003.py
@@ -5442,26 +5442,31 @@ items : (Io_Control_Spec_List, Format, Input_Item_List)
             idx = line.find(')')
             if idx == -1:
                 return
-            l = line[1:idx].strip()
-            if not l:
+            trimline = line[1:idx].strip()
+            if not trimline:
                 return
             if idx == len(line) - 1:
-                return Io_Control_Spec_List(repmap(l)), None, None
-            return Io_Control_Spec_List(repmap(l)), None, \
+                return Io_Control_Spec_List(repmap(trimline)), None, None
+            return Io_Control_Spec_List(repmap(trimline)), None, \
                 Input_Item_List(repmap(line[idx+1:].lstrip()))
         if not line:
             return
-        c = line[0].upper()
-        if 'A'<=c<='Z' or c=='_' or '0'<=c<='9':
+        char = line[0].upper()
+        # No parentheses therefore first argument must be a format
+        # specifier (either a string or a line/lable number
+        if 'A'<= char <= 'Z' or char == '_':
             return
         line, repmap = string_replace_map(line.lstrip())
-        i = line.find(',')
-        if i == -1:
-            return Format(repmap(line)), None, None
-        l = repmap(line[i+1:].lstrip())
-        if not l:
+        # There must be a comma betwee the format specifier and the following
+        # list of values/variables
+        idx = line.find(',')
+        if idx == -1:
+            return None
+        trimline = repmap(line[idx+1:].lstrip())
+        if not trimline:
             return
-        return None, Format(repmap(line[:i].rstrip())), Output_Item_List(l)
+        return (None, Format(repmap(line[:idx].rstrip())),
+                Output_Item_List(trimline))
     
     def tostr(self):
         if self.items[0] is not None:

--- a/src/fparser/Fortran2003.py
+++ b/src/fparser/Fortran2003.py
@@ -5454,7 +5454,7 @@ items : (Io_Control_Spec_List, Format, Input_Item_List)
         char = line[0].upper()
         # No parentheses therefore first argument must be a format
         # specifier (either a string or a line/lable number
-        if 'A'<= char <= 'Z' or char == '_':
+        if 'A' <= char <= 'Z' or char == '_':
             return
         line, repmap = string_replace_map(line.lstrip())
         # There must be a comma betwee the format specifier and the following
@@ -5569,7 +5569,7 @@ class Io_Control_Spec_List(SequenceBase): # R913-list
                 # a namelist specifier. However, if it is a character
                 # constant or "*" then it must be a Format spec and we can
                 # prepend "FMT=" to it.
-                spec =  spec.lstrip().rstrip()
+                spec = spec.lstrip().rstrip()
                 if Char_Literal_Constant.match(spec) or \
                    StringBase.match("*", spec):
                     spec = "FMT={0}".format(spec)
@@ -5609,24 +5609,22 @@ class Io_Control_Spec(KeywordValueBase): # R913
                  'Iomsg_Variable', 'Scalar_Int_Expr']
     @staticmethod
     def match(string):
-        for (k, v) in [\
-            ('UNIT', Io_Unit),
-            ('FMT', Format),
-            ('NML', Namelist_Group_Name)]:
+        for (k, v) in [('UNIT', Io_Unit),
+                       ('FMT', Format),
+                       ('NML', Namelist_Group_Name)]:
             obj = KeywordValueBase.match(k, v, string,
                                          require_lhs=False,
                                          upper_lhs=True)
             if obj:
                 return obj
 
-        for (k, v) in [\
-            (['ADVANCE', 'BLANK', 'DECIMAL', 'DELIM', 'PAD', 'ROUND', 'SIGN'],
-             Scalar_Default_Char_Expr),
-            ('ASYNCHRONOUS', Scalar_Char_Initialization_Expr),
-            (['END','EOR','ERR'], Label),
-            (['ID','IOSTAT','SIZE'], Scalar_Int_Variable),
-            ('IOMSG', Iomsg_Variable),
-            (['POS', 'REC'], Scalar_Int_Expr)]:
+        for (k, v) in [(['ADVANCE', 'BLANK', 'DECIMAL', 'DELIM', 'PAD',
+                         'ROUND', 'SIGN'], Scalar_Default_Char_Expr),
+                       ('ASYNCHRONOUS', Scalar_Char_Initialization_Expr),
+                       (['END', 'EOR', 'ERR'], Label),
+                       (['ID', 'IOSTAT', 'SIZE'], Scalar_Int_Variable),
+                       ('IOMSG', Iomsg_Variable),
+                       (['POS', 'REC'], Scalar_Int_Expr)]:
             obj = KeywordValueBase.match(k, v, string, upper_lhs=True)
             if obj:
                 return obj

--- a/src/fparser/tests/fparser2/test_base_classses.py
+++ b/src/fparser/tests/fparser2/test_base_classses.py
@@ -88,4 +88,3 @@ def test_io_ctrl_spec_errs():
     # description
     obj = Io_Control_Spec.match("not_unit=23")
     assert obj is None
-

--- a/src/fparser/tests/fparser2/test_base_classses.py
+++ b/src/fparser/tests/fparser2/test_base_classses.py
@@ -53,3 +53,19 @@ def test_read_stmt_errors():
     # Missing closing parenthesis
     obj = Read_Stmt.match("READ(unit=23")
     assert obj is None
+    # Missing arguments
+    obj = Read_Stmt.match("READ()")
+    assert obj is None
+    obj = Read_Stmt.match("READ")
+    assert obj is None
+    # Wrong argument type
+    obj = Read_Stmt.match("READ a_var")
+    assert obj is None
+    obj = Read_Stmt.match("READ 13")
+    assert obj is None
+    # Missing comma
+    obj = Read_Stmt.match("READ * a_var")
+    assert obj is None
+    # Missing value/variable after comma
+    obj = Read_Stmt.match("READ 13, ")
+    assert obj is None

--- a/src/fparser/tests/fparser2/test_base_classses.py
+++ b/src/fparser/tests/fparser2/test_base_classses.py
@@ -69,3 +69,23 @@ def test_read_stmt_errors():
     # Missing value/variable after comma
     obj = Read_Stmt.match("READ 13, ")
     assert obj is None
+
+
+def test_io_ctrl_spec_list_errs():
+    ''' Unit tests for the Io_Control_Spec_List class to ensure it
+    rejects invalid input '''
+    from fparser.Fortran2003 import Io_Control_Spec_List
+    # Positional arg following named arg
+    obj = Io_Control_Spec_List.match("unit=23, namvar")
+    assert obj is None
+
+
+def test_io_ctrl_spec_errs():
+    ''' Unit tests for the Io_Control_Spec class to ensure it
+    rejects invalid input '''
+    from fparser.Fortran2003 import Io_Control_Spec
+    # An argument with a name that is not valid within an IO control
+    # description
+    obj = Io_Control_Spec.match("not_unit=23")
+    assert obj is None
+

--- a/src/fparser/tests/fparser2/test_base_classses.py
+++ b/src/fparser/tests/fparser2/test_base_classses.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2017 Science and Technology Facilities Council
+
+# All rights reserved.
+
+# Modifications made as part of the fparser project are distributed
+# under the following license:
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+''' Module containing py.test tests for fparser2 base classes '''
+
+
+def test_keywordvaluebase():
+    ''' Unit tests for the KeywordValueBase class '''
+    from fparser.Fortran2003 import KeywordValueBase, Io_Unit
+    lhs_cls = 'UNIT'
+    rhs_cls = Io_Unit
+    obj = KeywordValueBase.match(lhs_cls, rhs_cls, "gurgle")
+    assert obj

--- a/src/fparser/tests/fparser2/test_base_classses.py
+++ b/src/fparser/tests/fparser2/test_base_classses.py
@@ -40,5 +40,7 @@ def test_keywordvaluebase():
     from fparser.Fortran2003 import KeywordValueBase, Io_Unit
     lhs_cls = 'UNIT'
     rhs_cls = Io_Unit
-    obj = KeywordValueBase.match(lhs_cls, rhs_cls, "gurgle")
-    assert obj
+    obj = KeywordValueBase.match(lhs_cls, rhs_cls, "  ", require_lhs=False)
+    assert obj is None
+    obj = KeywordValueBase.match(lhs_cls, rhs_cls, " = 36 ",)
+    assert obj is None

--- a/src/fparser/tests/fparser2/test_base_classses.py
+++ b/src/fparser/tests/fparser2/test_base_classses.py
@@ -35,8 +35,9 @@
 ''' Module containing py.test tests for fparser2 base classes '''
 
 
-def test_keywordvaluebase():
-    ''' Unit tests for the KeywordValueBase class '''
+def test_keywordvaluebase_errors():
+    ''' Unit tests for the KeywordValueBase class to check that it rejects
+    invalid input '''
     from fparser.Fortran2003 import KeywordValueBase, Io_Unit
     lhs_cls = 'UNIT'
     rhs_cls = Io_Unit
@@ -71,7 +72,7 @@ def test_read_stmt_errors():
     assert obj is None
 
 
-def test_io_ctrl_spec_list_errs():
+def test_io_ctrl_spec_list_errors():
     ''' Unit tests for the Io_Control_Spec_List class to ensure it
     rejects invalid input '''
     from fparser.Fortran2003 import Io_Control_Spec_List
@@ -80,7 +81,7 @@ def test_io_ctrl_spec_list_errs():
     assert obj is None
 
 
-def test_io_ctrl_spec_errs():
+def test_io_ctrl_spec_errors():
     ''' Unit tests for the Io_Control_Spec class to ensure it
     rejects invalid input '''
     from fparser.Fortran2003 import Io_Control_Spec

--- a/src/fparser/tests/fparser2/test_base_classses.py
+++ b/src/fparser/tests/fparser2/test_base_classses.py
@@ -44,3 +44,12 @@ def test_keywordvaluebase():
     assert obj is None
     obj = KeywordValueBase.match(lhs_cls, rhs_cls, " = 36 ",)
     assert obj is None
+
+
+def test_read_stmt_errors():
+    ''' Unit tests for the Read class to ensure it rejects invalid
+    inputs '''
+    from fparser.Fortran2003 import Read_Stmt
+    # Missing closing parenthesis
+    obj = Read_Stmt.match("READ(unit=23")
+    assert obj is None

--- a/src/fparser/tests/test_Fortran2003.py
+++ b/src/fparser/tests/test_Fortran2003.py
@@ -2540,48 +2540,48 @@ def test_Io_Unit(): # R901
         assert_equal(str(a),'a')
 
 
-def test_Read_Stmt(): # R910
+def test_read_stmt(): # R910
     ''' Check that we successfully parse various forms of READ statement '''
-    cls = Read_Stmt
-    obj = cls('read(123)')
-    assert isinstance(obj, cls), `obj`
-    assert str(obj) == 'READ(123)'
+    rcls = Read_Stmt
+    inst = rcls('read(123)')
+    assert isinstance(inst, rcls), `inst`
+    assert str(inst) == 'READ(123)'
 
-    obj = cls('read(123) a')
-    assert str(obj) == 'READ(123) a'
-    obj = cls('read(123) a(  2)')
-    assert str(obj) == 'READ(123) a(2)'
+    inst = rcls('read(123) a')
+    assert str(inst) == 'READ(123) a'
+    inst = rcls('read(123) a(  2)')
+    assert str(inst) == 'READ(123) a(2)'
 
-    obj = cls('read*, a(  2), b')
-    assert str(obj) == 'READ *, a(2), b'
+    inst = rcls('read*, a(  2), b')
+    assert str(inst) == 'READ *, a(2), b'
     # With format specified by label number
-    obj = cls("READ 13, a(2)")
-    assert str(obj) == 'READ 13, a(2)'
+    inst = rcls("READ 13, a(2)")
+    assert str(inst) == 'READ 13, a(2)'
 
     # If there is no preceding "FMT=" or "NML=" then there is no way of
     # knowing whether the second argument is a format string or a namelist
     # without determining the actual type of the argument.
-    obj = cls('read(123, a_namelist)')
-    assert str(obj) == "READ(123, a_namelist)"
+    inst = rcls('read(123, a_namelist)')
+    assert str(inst) == "READ(123, a_namelist)"
 
 
-def test_Write_Stmt(): # R911
+def test_write_stmt(): # R911
     ''' Tests for various forms of Write statement '''
-    cls = Write_Stmt
-    obj = cls('write (123)"hey"')
-    assert isinstance(obj, cls), `obj`
-    assert str(obj) == 'WRITE(123) "hey"'
-    assert (repr(obj) == "Write_Stmt(Io_Control_Spec_List(',', "
+    wcls = Write_Stmt
+    inst = wcls('write (123)"hey"')
+    assert isinstance(inst, wcls), `inst`
+    assert str(inst) == 'WRITE(123) "hey"'
+    assert (repr(inst) == "Write_Stmt(Io_Control_Spec_List(',', "
             "(Io_Control_Spec(None, Int_Literal_Constant('123', None)),)), "
             "Char_Literal_Constant('\"hey\"', None))")
 
-    obj = cls('WRITE (*,"(I3)") my_int')
-    assert isinstance(obj, cls), `obj`
-    assert str(obj) == 'WRITE(*, FMT = "(I3)") my_int'
+    inst = wcls('WRITE (*,"(I3)") my_int')
+    assert isinstance(inst, wcls), `inst`
+    assert str(inst) == 'WRITE(*, FMT = "(I3)") my_int'
 
-    obj = cls('WRITE (*,namtest)')
-    assert isinstance(obj, cls), `obj`
-    assert str(obj) == 'WRITE(*, namtest)'
+    inst = wcls('WRITE (*,namtest)')
+    assert isinstance(inst, wcls), `inst`
+    assert str(inst) == 'WRITE(*, namtest)'
 
 
 def test_Print_Stmt(): # R912
@@ -2606,37 +2606,38 @@ def test_Io_Control_Spec(): # R913
 
 
 def test_Io_Control_Spec_List(): # R913-list
+    ''' Test that we correctly parser and then generate various
+    forms of IO-control specification lists '''
+    iocls = Io_Control_Spec_List
+    inst = iocls('end=123')
+    assert isinstance(inst, iocls), `inst`
+    assert str(inst) == 'END = 123'
+    assert repr(inst) == \
+        "Io_Control_Spec_List(',', (Io_Control_Spec('END', Label('123')),))"
 
-        cls = Io_Control_Spec_List
-        a = cls('end=123')
-        assert isinstance(a, cls), `a`
-        assert str(a) == 'END = 123'
-        assert repr(a) == \
-            "Io_Control_Spec_List(',', (Io_Control_Spec('END', Label('123')),))"
+    inst = iocls('123')
+    assert isinstance(inst, iocls), `inst`
+    assert str(inst) == '123'
 
-        obj = cls('123')
-        assert isinstance(obj, cls), `obj`
-        assert str(obj) == '123'
+    inst = iocls('123,*')
+    assert isinstance(inst, iocls), `inst`
+    assert str(inst) == '123, FMT = *'
 
-        obj = cls('123,*')
-        assert isinstance(obj, cls), `obj`
-        assert str(obj) == '123, FMT = *'
+    inst = iocls('123,fmt=a')
+    assert isinstance(inst, iocls),`inst`
+    assert str(inst) == '123, FMT = a'
 
-        obj = cls('123,fmt=a')
-        assert isinstance(obj, cls),`obj`
-        assert str(obj) == '123, FMT = a'
+    inst = iocls('123,nml=a')
+    assert isinstance(inst, iocls),`inst`
+    assert str(inst) == '123, NML = a'
 
-        obj = cls('123,nml=a')
-        assert isinstance(obj, cls),`obj`
-        assert str(obj) == '123, NML = a'
+    inst = iocls('123, "(I3)"')
+    assert isinstance(inst, iocls),`inst`
+    assert str(inst) == '123, FMT = "(I3)"'
 
-        obj = cls('123, "(I3)"')
-        assert isinstance(obj, cls),`obj`
-        assert str(obj) == '123, FMT = "(I3)"'
-
-        obj = cls('123,a')
-        assert isinstance(obj, cls), `obj`
-        assert_equal(str(obj), '123, a')
+    inst = iocls('123,a')
+    assert isinstance(inst, iocls), `inst`
+    assert_equal(str(inst), '123, a')
 
 
 def test_Format(): # R914
@@ -2892,37 +2893,37 @@ def test_Format_Item(): # R1003
 def test_Edit_Desc():
     ''' Tests for matching Edit Descriptors '''
     cls = Data_Edit_Desc
-    obj = cls('I3')
-    assert str(obj) == 'I3'
+    inst = cls('I3')
+    assert str(inst) == 'I3'
 
-    obj = cls('I3.2')
-    assert str(obj) == 'I3.2'
+    inst = cls('I3.2')
+    assert str(inst) == 'I3.2'
 
-    obj = cls('O3.2')
-    assert str(obj) == 'O3.2'
+    inst = cls('O3.2')
+    assert str(inst) == 'O3.2'
 
-    obj = cls('Z3.2')
-    assert str(obj) == 'Z3.2'
+    inst = cls('Z3.2')
+    assert str(inst) == 'Z3.2'
 
-    obj = cls('L3')
-    assert str(obj) == 'L3'
+    inst = cls('L3')
+    assert str(inst) == 'L3'
 
     with pytest.raises(NoMatchError) as excinfo:
         _ = cls('L3.2')
     assert "NoMatchError: Data_Edit_Desc: 'L3.2'" in str(excinfo)
 
-    obj = cls('A3')
-    assert str(obj) == 'A3'
+    inst = cls('A3')
+    assert str(inst) == 'A3'
 
     with pytest.raises(NoMatchError) as excinfo:
         _ = cls('A3.2')
     assert "NoMatchError: Data_Edit_Desc: 'A3.2'" in str(excinfo)
 
-    obj = cls("DT'a_name'")
-    assert str(obj) == "DT'a_name'"
+    inst = cls("DT'a_name'")
+    assert str(inst) == "DT'a_name'"
 
-    obj = cls("DT'a_name'(3,-2)")
-    assert str(obj) == "DT'a_name'(3, -2)"
+    inst = cls("DT'a_name'(3,-2)")
+    assert str(inst) == "DT'a_name'(3, -2)"
 
     with pytest.raises(NoMatchError) as excinfo:
         _ = cls("DT'a_name'()")

--- a/src/fparser/tests/test_Fortran2003.py
+++ b/src/fparser/tests/test_Fortran2003.py
@@ -2561,8 +2561,8 @@ def test_read_stmt(): # R910
     # If there is no preceding "FMT=" or "NML=" then there is no way of
     # knowing whether the second argument is a format string or a namelist
     # without determining the actual type of the argument.
-    inst = rcls('read(123, a_namelist)')
-    assert str(inst) == "READ(123, a_namelist)"
+    inst = rcls('read(123, a_namelist_or_format)')
+    assert str(inst) == "READ(123, a_namelist_or_format)"
 
 
 def test_write_stmt(): # R911

--- a/src/fparser/tests/test_Fortran2003.py
+++ b/src/fparser/tests/test_Fortran2003.py
@@ -2554,7 +2554,10 @@ def test_Read_Stmt(): # R910
 
     obj = cls('read*, a(  2), b')
     assert str(obj) == 'READ *, a(2), b'
-    
+    # With format specified by label number
+    obj = cls("READ 13, a(2)")
+    assert str(obj) == 'READ 13, a(2)'
+
     # If there is no preceding "FMT=" or "NML=" then there is no way of
     # knowing whether the second argument is a format string or a namelist
     # without determining the actual type of the argument.

--- a/src/fparser/tests/test_Fortran2003.py
+++ b/src/fparser/tests/test_Fortran2003.py
@@ -2554,15 +2554,26 @@ def test_read_stmt(): # R910
 
     inst = rcls('read*, a(  2), b')
     assert str(inst) == 'READ *, a(2), b'
+    assert repr(inst) == (
+        "Read_Stmt(None, Format('*'), Output_Item_List(',', (Part_Ref("
+        "Name('a'), Int_Literal_Constant('2', None)), Name('b'))))")
+
     # With format specified by label number
     inst = rcls("READ 13, a(2)")
     assert str(inst) == 'READ 13, a(2)'
+    print repr(inst)
+    assert repr(inst) == ("Read_Stmt(None, Label('13'), Part_Ref(Name('a'), "
+                          "Int_Literal_Constant('2', None)))")
 
     # If there is no preceding "FMT=" or "NML=" then there is no way of
     # knowing whether the second argument is a format string or a namelist
     # without determining the actual type of the argument.
     inst = rcls('read(123, a_namelist_or_format)')
     assert str(inst) == "READ(123, a_namelist_or_format)"
+    assert repr(inst) == ("Read_Stmt(Io_Control_Spec_List(',', "
+                          "(Io_Control_Spec(None, Int_Literal_Constant('123', "
+                          "None)), Io_Control_Spec(None, "
+                          "Name('a_namelist_or_format')))), None, None)")
 
 
 def test_write_stmt(): # R911
@@ -2571,17 +2582,26 @@ def test_write_stmt(): # R911
     inst = wcls('write (123)"hey"')
     assert isinstance(inst, wcls), `inst`
     assert str(inst) == 'WRITE(123) "hey"'
-    assert (repr(inst) == "Write_Stmt(Io_Control_Spec_List(',', "
-            "(Io_Control_Spec(None, Int_Literal_Constant('123', None)),)), "
-            "Char_Literal_Constant('\"hey\"', None))")
+    assert repr(inst) == (
+        "Write_Stmt(Io_Control_Spec_List(',', "
+        "(Io_Control_Spec(None, Int_Literal_Constant('123', None)),)), "
+        "Char_Literal_Constant('\"hey\"', None))")
 
     inst = wcls('WRITE (*,"(I3)") my_int')
     assert isinstance(inst, wcls), `inst`
     assert str(inst) == 'WRITE(*, FMT = "(I3)") my_int'
+    assert repr(inst) == (
+        "Write_Stmt(Io_Control_Spec_List(',', "
+        "(Io_Control_Spec(None, Io_Unit('*')), Io_Control_Spec('FMT', "
+        "Char_Literal_Constant('\"(I3)\"', None)))), Name('my_int'))")
 
     inst = wcls('WRITE (*,namtest)')
     assert isinstance(inst, wcls), `inst`
     assert str(inst) == 'WRITE(*, namtest)'
+    assert repr(inst) == (
+        "Write_Stmt(Io_Control_Spec_List(',', "
+        "(Io_Control_Spec(None, Io_Unit('*')), Io_Control_Spec(None, "
+        "Name('namtest')))), None)")
 
 
 def test_Print_Stmt(): # R912
@@ -2606,7 +2626,7 @@ def test_Io_Control_Spec(): # R913
 
 
 def test_Io_Control_Spec_List(): # R913-list
-    ''' Test that we correctly parser and then generate various
+    ''' Test that we correctly parse and then generate various
     forms of IO-control specification lists '''
     iocls = Io_Control_Spec_List
     inst = iocls('end=123')
@@ -2622,14 +2642,23 @@ def test_Io_Control_Spec_List(): # R913-list
     inst = iocls('123,*')
     assert isinstance(inst, iocls), `inst`
     assert str(inst) == '123, FMT = *'
+    assert repr(inst) == ("Io_Control_Spec_List(',', (Io_Control_Spec(None, "
+                          "Int_Literal_Constant('123', None)), "
+                          "Io_Control_Spec('FMT', Format('*'))))")
 
     inst = iocls('123,fmt=a')
     assert isinstance(inst, iocls),`inst`
     assert str(inst) == '123, FMT = a'
+    assert repr(inst) == ("Io_Control_Spec_List(',', (Io_Control_Spec(None, "
+                          "Int_Literal_Constant('123', None)), "
+                          "Io_Control_Spec('FMT', Name('a'))))")
 
     inst = iocls('123,nml=a')
     assert isinstance(inst, iocls),`inst`
     assert str(inst) == '123, NML = a'
+    assert repr(inst) == ("Io_Control_Spec_List(',', (Io_Control_Spec(None, "
+                          "Int_Literal_Constant('123', None)), "
+                          "Io_Control_Spec('NML', Name('a'))))")
 
     inst = iocls('123, "(I3)"')
     assert isinstance(inst, iocls),`inst`

--- a/src/fparser/tests/test_Fortran2003.py
+++ b/src/fparser/tests/test_Fortran2003.py
@@ -2545,12 +2545,12 @@ def test_Read_Stmt(): # R910
     cls = Read_Stmt
     obj = cls('read(123)')
     assert isinstance(obj, cls), `obj`
-    assert str(obj) == 'READ(UNIT = 123)'
+    assert str(obj) == 'READ(123)'
 
     obj = cls('read(123) a')
-    assert str(obj) == 'READ(UNIT = 123) a'
+    assert str(obj) == 'READ(123) a'
     obj = cls('read(123) a(  2)')
-    assert str(obj) == 'READ(UNIT = 123) a(2)'
+    assert str(obj) == 'READ(123) a(2)'
 
     obj = cls('read*, a(  2), b')
     assert str(obj) == 'READ *, a(2), b'
@@ -2563,12 +2563,23 @@ def test_Read_Stmt(): # R910
 
 
 def test_Write_Stmt(): # R911
+    ''' Tests for various forms of Write statement '''
+    cls = Write_Stmt
+    obj = cls('write (123)"hey"')
+    assert isinstance(obj, cls), `obj`
+    assert str(obj) == 'WRITE(123) "hey"'
+    assert (repr(obj) == "Write_Stmt(Io_Control_Spec_List(',', "
+            "(Io_Control_Spec(None, Int_Literal_Constant('123', None)),)), "
+            "Char_Literal_Constant('\"hey\"', None))")
 
-        cls = Write_Stmt
-        a = cls('write (123)"hey"')
-        assert isinstance(a, cls),`a`
-        assert_equal(str(a),'WRITE(UNIT = 123) "hey"')
-        assert_equal(repr(a),'Write_Stmt(Io_Control_Spec_List(\',\', (Io_Control_Spec(\'UNIT\', Int_Literal_Constant(\'123\', None)),)), Char_Literal_Constant(\'"hey"\', None))')
+    obj = cls('WRITE (*,"(I3)") my_int')
+    assert isinstance(obj, cls), `obj`
+    assert str(obj) == 'WRITE(*, FMT = "(I3)") my_int'
+
+    obj = cls('WRITE (*,namtest)')
+    assert isinstance(obj, cls), `obj`
+    assert str(obj) == 'WRITE(*, namtest)'
+
 
 def test_Print_Stmt(): # R912
 
@@ -2590,31 +2601,40 @@ def test_Io_Control_Spec(): # R913
         assert_equal(str(a),'END = 123')
         assert_equal(repr(a),"Io_Control_Spec('END', Label('123'))")
 
+
 def test_Io_Control_Spec_List(): # R913-list
 
         cls = Io_Control_Spec_List
         a = cls('end=123')
-        assert isinstance(a, cls),`a`
-        assert_equal(str(a),'END = 123')
-        assert_equal(repr(a),"Io_Control_Spec_List(',', (Io_Control_Spec('END', Label('123')),))")
+        assert isinstance(a, cls), `a`
+        assert str(a) == 'END = 123'
+        assert repr(a) == \
+            "Io_Control_Spec_List(',', (Io_Control_Spec('END', Label('123')),))"
 
-        a = cls('123')
-        assert isinstance(a, cls),`a`
-        assert_equal(str(a),'UNIT = 123')
+        obj = cls('123')
+        assert isinstance(obj, cls), `obj`
+        assert str(obj) == '123'
 
-        a = cls('123,*')
-        assert isinstance(a, cls),`a`
-        assert_equal(str(a),'UNIT = 123, FMT = *')
+        obj = cls('123,*')
+        assert isinstance(obj, cls), `obj`
+        assert str(obj) == '123, FMT = *'
 
-        a = cls('123,fmt=a')
-        assert isinstance(a, cls),`a`
-        assert_equal(str(a),'UNIT = 123, FMT = a')
+        obj = cls('123,fmt=a')
+        assert isinstance(obj, cls),`obj`
+        assert str(obj) == '123, FMT = a'
 
-        if 0:
-            # see todo note in Io_Control_Spec_List
-            a = cls('123,a')
-            assert isinstance(a, cls),`a`
-            assert_equal(str(a),'UNIT = 123, NML = a')
+        obj = cls('123,nml=a')
+        assert isinstance(obj, cls),`obj`
+        assert str(obj) == '123, NML = a'
+
+        obj = cls('123, "(I3)"')
+        assert isinstance(obj, cls),`obj`
+        assert str(obj) == '123, FMT = "(I3)"'
+
+        obj = cls('123,a')
+        assert isinstance(obj, cls), `obj`
+        assert_equal(str(obj), '123, a')
+
 
 def test_Format(): # R914
 

--- a/src/fparser/tests/test_Fortran2003.py
+++ b/src/fparser/tests/test_Fortran2003.py
@@ -2539,20 +2539,29 @@ def test_Io_Unit(): # R901
         assert isinstance(a, Name),`a`
         assert_equal(str(a),'a')
 
+
 def test_Read_Stmt(): # R910
+    ''' Check that we successfully parse various forms of READ statement '''
     cls = Read_Stmt
-    a = cls('read(123)')
-    assert isinstance(a, cls),`a`
-    assert_equal(str(a), 'READ(UNIT = 123)')
+    obj = cls('read(123)')
+    assert isinstance(obj, cls), `obj`
+    assert str(obj) == 'READ(UNIT = 123)'
 
-    a = cls('read(123) a')
-    assert_equal(str(a), 'READ(UNIT = 123) a')
-    a = cls('read(123) a(  2)')
-    assert_equal(str(a), 'READ(UNIT = 123) a(2)')
+    obj = cls('read(123) a')
+    assert str(obj) == 'READ(UNIT = 123) a'
+    obj = cls('read(123) a(  2)')
+    assert str(obj) == 'READ(UNIT = 123) a(2)'
 
-    a = cls('read*, a(  2), b')
-    assert_equal(str(a), 'READ *, a(2), b')
+    obj = cls('read*, a(  2), b')
+    assert str(obj) == 'READ *, a(2), b'
     
+    # If there is no preceding "FMT=" or "NML=" then there is no way of
+    # knowing whether the second argument is a format string or a namelist
+    # without determining the actual type of the argument.
+    obj = cls('read(123, a_namelist)')
+    assert str(obj) == "READ(123, a_namelist)"
+
+
 def test_Write_Stmt(): # R911
 
         cls = Write_Stmt


### PR DESCRIPTION
This PR is for #34 and fixes fparser's assumption that a second, positional item in an IO control list is always a Format (it may be a namelist).