### PR TITLE
Fix #45: The optional '::' in a module procedure declaration was not

### DIFF
--- a/src/fparser/statements.py
+++ b/src/fparser/statements.py
@@ -628,15 +628,17 @@ class Deallocate(Statement):
         + 'DEALLOCATE (%s)' % (', '.join(self.items))
     def analyze(self): return
 
+
 class ModuleProcedure(Statement):
     """
     [ MODULE ] PROCEDURE [::] <procedure-name-list>
     """
-    match = re.compile(r'(module\s*|)procedure\b *(::)?',re.I).match
+    match = re.compile(r'(module\s*|)procedure\b\s*(::)?', re.I).match
+
     def process_item(self):
         line = self.item.get_line()
         m = self.match(line)
-        assert m,`line`
+        assert m, line.repr()
         items = split_comma(line[m.end():].strip(), self.item)
         for n in items:
             if not is_name(n):
@@ -654,6 +656,7 @@ class ModuleProcedure(Statement):
         module_procedures.extend(self.items)
         # XXX: add names to parent_provides
         return
+
 
 class Access(Statement):
     """

--- a/src/fparser/statements.py
+++ b/src/fparser/statements.py
@@ -630,9 +630,9 @@ class Deallocate(Statement):
 
 class ModuleProcedure(Statement):
     """
-    [ MODULE ] PROCEDURE <procedure-name-list>
+    [ MODULE ] PROCEDURE [::] <procedure-name-list>
     """
-    match = re.compile(r'(module\s*|)procedure\b',re.I).match
+    match = re.compile(r'(module\s*|)procedure\b *(::)?',re.I).match
     def process_item(self):
         line = self.item.get_line()
         m = self.match(line)

--- a/src/fparser/tests/test_parser.py
+++ b/src/fparser/tests/test_parser.py
@@ -195,9 +195,23 @@ def test_deallocate():
 
 def test_moduleprocedure():
     assert_equal(parse(ModuleProcedure,\
+                       'Procedure a'), 'MODULE PROCEDURE a')
+    assert_equal(parse(ModuleProcedure,\
+                       'procedure a , b'), 'MODULE PROCEDURE a, b')
+    assert_equal(parse(ModuleProcedure,\
+                       'procedure :: a '), 'MODULE PROCEDURE a')
+    assert_equal(parse(ModuleProcedure,\
+                       'procedure :: a , b'), 'MODULE PROCEDURE a, b')
+    assert_equal(parse(ModuleProcedure,\
                        'ModuleProcedure a'), 'MODULE PROCEDURE a')
     assert_equal(parse(ModuleProcedure,\
                        'module procedure a , b'), 'MODULE PROCEDURE a, b')
+    assert_equal(parse(ModuleProcedure,\
+                       'module procedure :: a '), 'MODULE PROCEDURE a')
+    assert_equal(parse(ModuleProcedure,\
+                       'module procedure :: a , b'), 'MODULE PROCEDURE a, b')
+    assert_equal(parse(ModuleProcedure,\
+                       'moduleprocedure::a,b'), 'MODULE PROCEDURE a, b')
 
 def test_access():
     assert_equal(parse(Public,'Public'),'PUBLIC')

--- a/src/fparser/tests/test_parser.py
+++ b/src/fparser/tests/test_parser.py
@@ -193,25 +193,28 @@ def test_deallocate():
     assert_equal(parse(Deallocate, 'deallocate (a)'), 'DEALLOCATE (a)')
     assert_equal(parse(Deallocate, 'deallocate (a, stat=b)'), 'DEALLOCATE (a, STAT = b)')
 
+
 def test_moduleprocedure():
-    assert_equal(parse(ModuleProcedure,\
-                       'Procedure a'), 'MODULE PROCEDURE a')
-    assert_equal(parse(ModuleProcedure,\
-                       'procedure a , b'), 'MODULE PROCEDURE a, b')
-    assert_equal(parse(ModuleProcedure,\
-                       'procedure :: a '), 'MODULE PROCEDURE a')
-    assert_equal(parse(ModuleProcedure,\
-                       'procedure :: a , b'), 'MODULE PROCEDURE a, b')
-    assert_equal(parse(ModuleProcedure,\
-                       'ModuleProcedure a'), 'MODULE PROCEDURE a')
-    assert_equal(parse(ModuleProcedure,\
-                       'module procedure a , b'), 'MODULE PROCEDURE a, b')
-    assert_equal(parse(ModuleProcedure,\
-                       'module procedure :: a '), 'MODULE PROCEDURE a')
-    assert_equal(parse(ModuleProcedure,\
-                       'module procedure :: a , b'), 'MODULE PROCEDURE a, b')
-    assert_equal(parse(ModuleProcedure,\
-                       'moduleprocedure::a,b'), 'MODULE PROCEDURE a, b')
+    ''' Test  [ MODULE ] PROCEDURE [::] <procedure-name-list> '''
+
+    assert parse(ModuleProcedure, 'Procedure a') == 'MODULE PROCEDURE a'
+    assert parse(ModuleProcedure, 'procedure a , b') == \
+        'MODULE PROCEDURE a, b'
+    assert parse(ModuleProcedure, 'procedure :: a ') == \
+        'MODULE PROCEDURE a'
+    assert parse(ModuleProcedure, 'procedure :: a , b') == \
+        'MODULE PROCEDURE a, b'
+    assert parse(ModuleProcedure, 'ModuleProcedure a') == \
+        'MODULE PROCEDURE a'
+    assert parse(ModuleProcedure, 'module procedure a , b') == \
+        'MODULE PROCEDURE a, b'
+    assert parse(ModuleProcedure, 'module procedure :: a ') == \
+        'MODULE PROCEDURE a'
+    assert parse(ModuleProcedure, 'module procedure :: a , b') == \
+        'MODULE PROCEDURE a, b'
+    assert parse(ModuleProcedure, 'moduleprocedure::a,b') == \
+           'MODULE PROCEDURE a, b'
+
 
 def test_access():
     assert_equal(parse(Public,'Public'),'PUBLIC')


### PR DESCRIPTION
accepted. Added test case for usage of '::", and also test cases
for module procedure declaration without the (optional) 'module'.