### PR TITLE
#36 fix missing unit number for open statements

### DIFF
--- a/src/fparser/Fortran2003.py
+++ b/src/fparser/Fortran2003.py
@@ -7601,7 +7601,7 @@ ClassType = type(Base)
 _names = dir()
 for clsname in _names:
     cls = eval(clsname)
-    if not (isinstance(cls, ClassType) and issubclass(cls, Base) and \
+    if not (isinstance(cls, ClassType) and issubclass(cls, Base) and
             not cls.__name__.endswith('Base')):
         continue
     names = getattr(cls, 'subclass_names', []) + getattr(cls, 'use_names', [])

--- a/src/fparser/Fortran2003.py
+++ b/src/fparser/Fortran2003.py
@@ -161,8 +161,16 @@ class Base(ComparableMixin):
     subclasses = {}
 
     @show_result
-    def __new__(cls, string, parent_cls = None):
+    def __new__(cls, string, parent_cls=None):
         """
+        Create a new instance of this object.
+
+        :param cls: the class of object to create
+        :type cls: :py:type:`type`
+        :param string: (source of) Fortran string to parse
+        :type string: str or :py:class:`FortranReaderBase`
+        :param parent_cls: the parent class of this object
+        :type parent_cls: :py:type:`type`
         """
         if parent_cls is None:
             parent_cls = [cls]
@@ -5421,6 +5429,16 @@ class Connect_Spec(KeywordValueBase):
 
     @staticmethod
     def match(string):
+        '''
+        :param str string: Fortran code to check for a match
+        :return: 2-tuple containing the keyword and value or None if the
+                 supplied string is not a match
+        :rtype: 2-tuple containing keyword (e.g. "UNIT") and associated value
+        '''
+        if "=" not in string:
+            # The only argument which need not be named is the unit number
+            return 'UNIT', File_Unit_Number(string)
+        # We have a keyword-value pair. Check whether it is valid...
         for (keyword, value) in [
                 (['ACCESS', 'ACTION', 'ASYNCHRONOUS', 'BLANK', 'DECIMAL',
                   'DELIM', 'ENCODING', 'FORM', 'PAD', 'POSITION', 'ROUND',
@@ -5438,7 +5456,7 @@ class Connect_Spec(KeywordValueBase):
                 obj = None
             if obj is not None:
                 return obj
-        return 'UNIT', File_Unit_Number(string)
+        return None
 
 
 class File_Name_Expr(Base): # R906
@@ -6084,6 +6102,18 @@ class Inquire_Spec(KeywordValueBase):  # R930
 
     @staticmethod
     def match(string):
+        '''
+        :param str string: The string to check for conformance with an
+                           Inquire_Spec
+        :return: 2-tuple of name (e.g. "UNIT") and value or None if
+                 string is not a valid Inquire_Spec
+        :rtype: 2-tuple where first object represents the name and the
+                second the value.
+        '''
+        if "=" not in string:
+            # The only argument which need not be named is the unit number
+            return 'UNIT', File_Unit_Number(string)
+        # We have a keyword-value pair. Check whether it is valid...
         for (keyword, value) in [
                 (['ACCESS', 'ACTION', 'ASYNCHRONOUS', 'BLANK', 'DECIMAL',
                   'DELIM', 'DIRECT', 'ENCODING', 'FORM', 'NAME', 'PAD',
@@ -6106,7 +6136,7 @@ class Inquire_Spec(KeywordValueBase):  # R930
                 obj = None
             if obj is not None:
                 return obj
-        return 'UNIT', File_Unit_Number(string)
+        return None
 
 ###############################################################################
 ############################### SECTION 10 ####################################

--- a/src/fparser/tests/fparser2/test_Fortran2003.py
+++ b/src/fparser/tests/fparser2/test_Fortran2003.py
@@ -2866,6 +2866,15 @@ def test_Open_Stmt():
     assert str(obj) == "OPEN(UNIT = 23, FILE = 'some_file.txt')"
 
 
+def test_Connect_Spec():
+    ''' Tests for individual elements of Connect_Spec (R905) '''
+    cls = Connect_Spec
+    # Incorrect name for a member of the list
+    with pytest.raises(NoMatchError) as excinfo:
+        _ = cls("afile='a_file.dat'")
+    assert 'NoMatchError: Connect_Spec: "afile=' in str(excinfo)
+
+
 def test_Connect_Spec_List():  # pylint: disable=invalid-name
     '''
     Check that we correctly parse the various valid forms of
@@ -2944,10 +2953,11 @@ def test_Connect_Spec_List():  # pylint: disable=invalid-name
     assert isinstance(obj, cls)
     assert str(obj) == ("UNIT = 22, FILE = 'a_file.dat', SIGN = 'PLUS', "
                         "STATUS = 'OLD'")
+
     # Incorrect name for a member of the list
     with pytest.raises(NoMatchError) as excinfo:
-        _ = cls("22, afile='a_file.dat', sign='PLUS', status='OLD'")
-    assert 'NoMatchError: Connect_Spec_List: "22, afile=' in str(excinfo)
+        _ = cls("unit=22, afile='a_file.dat', sign='PLUS', status='OLD'")
+    assert 'NoMatchError: Connect_Spec_List: "unit=22, afile=' in str(excinfo)
 
 
 ###############################################################################

--- a/src/fparser/tests/fparser2/test_Fortran2003.py
+++ b/src/fparser/tests/fparser2/test_Fortran2003.py
@@ -2837,6 +2837,97 @@ def test_Inquire_Spec():  # R930
     assert_equal(str(obj), 'DIRECT = a')
 
 
+def test_Open_Stmt():
+    ''' Check that we correctly parse and re-generate the various forms
+    of OPEN statement (R904)'''
+    cls = Open_Stmt
+    obj = cls("open(23, file='some_file.txt')")
+    assert isinstance(obj, cls)
+    assert str(obj) == "OPEN(UNIT = 23, FILE = 'some_file.txt')"
+    obj = cls("open(unit=23, file='some_file.txt')")
+    assert isinstance(obj, cls)
+    assert str(obj) == "OPEN(UNIT = 23, FILE = 'some_file.txt')"
+
+
+def test_Connect_Spec_List():  # pylint: disable=invalid-name
+    '''
+    Check that we correctly parse the various valid forms of
+    connect specification (R905)
+    '''
+    cls = Connect_Spec_List
+    obj = cls("22, access='direct'")
+    assert isinstance(obj, cls)
+    assert str(obj) == "UNIT = 22, ACCESS = 'direct'"
+
+    obj = cls("22, action='read'")
+    assert isinstance(obj, cls)
+    assert str(obj) == "UNIT = 22, ACTION = 'read'"
+
+    obj = cls("22, asynchronous='YES'")
+    assert isinstance(obj, cls)
+    assert str(obj) == "UNIT = 22, ASYNCHRONOUS = 'YES'"
+
+    obj = cls("22, blank='NULL'")
+    assert isinstance(obj, cls)
+    assert str(obj) == "UNIT = 22, BLANK = 'NULL'"
+
+    obj = cls("22, decimal='COMMA'")
+    assert isinstance(obj, cls)
+    assert str(obj) == "UNIT = 22, DECIMAL = 'COMMA'"
+
+    obj = cls("22, delim='APOSTROPHE'")
+    assert isinstance(obj, cls)
+    assert str(obj) == "UNIT = 22, DELIM = 'APOSTROPHE'"
+
+    obj = cls("22, err=109")
+    assert isinstance(obj, cls)
+    assert str(obj) == "UNIT = 22, ERR = 109"
+
+    obj = cls("22, encoding='DEFAULT'")
+    assert isinstance(obj, cls)
+    assert str(obj) == "UNIT = 22, ENCODING = 'DEFAULT'"
+
+    obj = cls("22, file='a_file.dat'")
+    assert isinstance(obj, cls)
+    assert str(obj) == "UNIT = 22, FILE = 'a_file.dat'"
+
+    obj = cls("22, file='a_file.dat', form='FORMATTED'")
+    assert isinstance(obj, cls)
+    assert str(obj) == "UNIT = 22, FILE = 'a_file.dat', FORM = 'FORMATTED'"
+
+    obj = cls("22, file='a_file.dat', iomsg=my_string")
+    assert isinstance(obj, cls)
+    assert str(obj) == "UNIT = 22, FILE = 'a_file.dat', IOMSG = my_string"
+
+    obj = cls("22, file='a_file.dat', iostat=ierr")
+    assert isinstance(obj, cls)
+    assert str(obj) == "UNIT = 22, FILE = 'a_file.dat', IOSTAT = ierr"
+
+    obj = cls("22, file='a_file.dat', pad='YES'")
+    assert isinstance(obj, cls)
+    assert str(obj) == "UNIT = 22, FILE = 'a_file.dat', PAD = 'YES'"
+
+    obj = cls("22, file='a_file.dat', position='APPEND'")
+    assert isinstance(obj, cls)
+    assert str(obj) == "UNIT = 22, FILE = 'a_file.dat', POSITION = 'APPEND'"
+
+    obj = cls("22, file='a_file.dat', recl=100")
+    assert isinstance(obj, cls)
+    assert str(obj) == "UNIT = 22, FILE = 'a_file.dat', RECL = 100"
+
+    obj = cls("22, file='a_file.dat', round='UP'")
+    assert isinstance(obj, cls)
+    assert str(obj) == "UNIT = 22, FILE = 'a_file.dat', ROUND = 'UP'"
+
+    obj = cls("22, file='a_file.dat', sign='PLUS'")
+    assert isinstance(obj, cls)
+    assert str(obj) == "UNIT = 22, FILE = 'a_file.dat', SIGN = 'PLUS'"
+
+    obj = cls("22, file='a_file.dat', sign='PLUS', status='OLD'")
+    assert isinstance(obj, cls)
+    assert str(obj) == ("UNIT = 22, FILE = 'a_file.dat', SIGN = 'PLUS', "
+                        "STATUS = 'OLD'")
+
 
 ###############################################################################
 ############################### SECTION 10 ####################################
@@ -3664,42 +3755,43 @@ def test_Contains(): # R1237
 
 
 if 0:
-    nof_needed_tests = 0
-    nof_needed_match = 0
-    total_needs = 0
-    total_classes = 0
-    for name in dir():
-        obj = eval(name)
-        if not isinstance(obj, ClassType): continue
-        if not issubclass(obj, Base): continue
-        clsname = obj.__name__
-        if clsname.endswith('Base'): continue
-        total_classes += 1
-        subclass_names = obj.__dict__.get('subclass_names',None)
-        use_names = obj.__dict__.get('use_names',None)
-        if not use_names: continue
-        match = obj.__dict__.get('match',None)
+    NOF_NEEDED_TESTS = 0
+    NOF_NEEDED_MATCH = 0
+    TOTAL_NEEDS = 0
+    TOTAL_CLASSES = 0
+    for NAME in dir():
+        OBJ = eval(NAME)
+        if not isinstance(OBJ, ClassType): continue
+        if not issubclass(OBJ, Base): continue
+        CLSNAME = OBJ.__name__
+        if CLSNAME.endswith('Base'): continue
+        TOTAL_CLASSES += 1
+        SUBCLASS_NAMES = OBJ.__dict__.get('subclass_names', None)
+        USE_NAMES = OBJ.__dict__.get('use_names', None)
+        if not USE_NAMES: continue
+        MATCH = OBJ.__dict__.get('match', None)
         try:
-            test_cls = eval('test_%s' % (clsname))
+            TEST_CLS = eval('test_{0}'.format(CLSNAME))
         except NameError:
-            test_cls = None
-        total_needs += 1
-        if match is None:
-            if test_cls is None:
-                print('Needs tests:', clsname)
-                print('Needs match implementation:', clsname)
-                nof_needed_tests += 1
-                nof_needed_match += 1
+            TEST_CLS = None
+        TOTAL_NEEDS += 1
+        if MATCH is None:
+            if TEST_CLS is None:
+                print('Needs tests:', CLSNAME)
+                print('Needs match implementation:', CLSNAME)
+                NOF_NEEDED_TESTS += 1
+                NOF_NEEDED_MATCH += 1
             else:
-                print('Needs match implementation:', clsname)
-                nof_needed_match += 1
+                print('Needs match implementation:', CLSNAME)
+                NOF_NEEDED_MATCH += 1
         else:
-            if test_cls is None:
-                print('Needs tests:', clsname)
-                nof_needed_tests += 1
+            if TEST_CLS is None:
+                print('Needs tests:', CLSNAME)
+                NOF_NEEDED_TESTS += 1
         continue
     print('-----')
-    print('Nof match implementation needs:',nof_needed_match,'out of',total_needs)
-    print('Nof tests needs:',nof_needed_tests,'out of',total_needs)
-    print('Total number of classes:',total_classes)
+    print('Nof match implementation needs:', NOF_NEEDED_MATCH,
+          'out of', TOTAL_NEEDS)
+    print('Nof tests needs:', NOF_NEEDED_TESTS, 'out of', TOTAL_NEEDS)
+    print('Total number of classes:', TOTAL_CLASSES)
     print('-----')

--- a/src/fparser/tests/fparser2/test_Fortran2003.py
+++ b/src/fparser/tests/fparser2/test_Fortran2003.py
@@ -2811,7 +2811,7 @@ def test_Inquire_Stmt():  # R929
 
 def test_Inquire_Spec():  # R930
     ''' Test that we recognise the various possible forms of
-    inquire list '''
+    entries in an inquire list '''
     cls = Inquire_Spec
     obj = cls('1')
     assert isinstance(obj, cls), repr(obj)
@@ -2835,6 +2835,23 @@ def test_Inquire_Spec():  # R930
     obj = cls('direct=a')
     assert isinstance(obj, cls), repr(obj)
     assert_equal(str(obj), 'DIRECT = a')
+
+
+def test_Inquire_Spec_List():  # pylint: disable=invalid-name
+    ''' Test that we recognise the various possible forms of
+    inquire list - R930
+    '''
+    # Inquire_Spec_List is generated at runtime in Fortran2003.py
+    cls = Inquire_Spec_List
+
+    obj = cls('unit=23, file="a_file.dat"')
+    assert isinstance(obj, cls)
+    assert str(obj) == 'UNIT = 23, FILE = "a_file.dat"'
+
+    # Invalid list (afile= instead of file=)
+    with pytest.raises(NoMatchError) as excinfo:
+        _ = cls('unit=23, afile="a_file.dat"')
+    assert "NoMatchError: Inquire_Spec_List: 'unit=23, afile=" in str(excinfo)
 
 
 def test_Open_Stmt():
@@ -2927,6 +2944,10 @@ def test_Connect_Spec_List():  # pylint: disable=invalid-name
     assert isinstance(obj, cls)
     assert str(obj) == ("UNIT = 22, FILE = 'a_file.dat', SIGN = 'PLUS', "
                         "STATUS = 'OLD'")
+    # Incorrect name for a member of the list
+    with pytest.raises(NoMatchError) as excinfo:
+        _ = cls("22, afile='a_file.dat', sign='PLUS', status='OLD'")
+    assert 'NoMatchError: Connect_Spec_List: "22, afile=' in str(excinfo)
 
 
 ###############################################################################


### PR DESCRIPTION
This PR fixes #36 by correcting the `match` method of `Connect_Spec`.