### PR TITLE
Declaration with array assignment

### DIFF
--- a/src/fparser/readfortran.py
+++ b/src/fparser/readfortran.py
@@ -920,10 +920,6 @@ class FortranReaderBase(object):
                 if self.isf77 or not line[i:].startswith('!f2py'):
                     put_item(self.comment_item(line[i:], lineno, lineno))
                     return newline, quotechar, True
-        # handle cases where comment char may be a part of a character content
-        #splitter = LineSplitter(line, quotechar)
-        #items = [item for item in splitter]
-        #newquotechar = splitter.quotechar
         items, newquotechar = splitquote(line, quotechar)
 
         noncomment_items = []

--- a/src/fparser/splitline.py
+++ b/src/fparser/splitline.py
@@ -72,18 +72,28 @@ First version created: May 2006
 -----
 """
 
-__all__ = ['String','string_replace_map','splitquote','splitparen']
 
 import re
 
-class String(str): pass
-class ParenString(str): pass
 
+class String(str):
+    '''Dummy string class'''
+    pass
+
+
+class ParenString(str):
+    '''Class representing a parenthesis string.'''
+    pass
+
+
+__all__ = ['String', 'string_replace_map', 'splitquote', 'splitparen']
 
 _f2py_str_findall = re.compile(r"_F2PY_STRING_CONSTANT_\d+_").findall
-_is_name = re.compile(r'\w*\Z',re.I).match
-_is_simple_str = re.compile(r'\w*\Z',re.I).match
-_f2py_findall = re.compile(r'(_F2PY_STRING_CONSTANT_\d+_|F2PY_EXPR_TUPLE_\d+)').findall
+_is_name = re.compile(r'\w*\Z', re.I).match
+_is_simple_str = re.compile(r'\w*\Z', re.I).match
+_f2py_findall = re.compile(r'(_F2PY_STRING_CONSTANT_\d+_|F2PY_EXPR_TUPLE_\d+)'
+                           ).findall
+
 
 class string_replace_dict(dict):
     """
@@ -95,8 +105,9 @@ class string_replace_dict(dict):
             line = line.replace(k, self[k])
         return line
 
+
 def string_replace_map(line, lower=False,
-                       _cache={'index':0,'pindex':0}):
+                       _cache={'index': 0, 'pindex': 0}):
     """
     1) Replaces string constants with symbol `'_F2PY_STRING_CONSTANT_<index>_'`
     2) Replaces (expression) with symbol `(F2PY_EXPR_TUPLE_<index>)`
@@ -148,7 +159,8 @@ def string_replace_map(line, lower=False,
         del string_map[k]
     return ''.join(items), string_map
 
-def splitquote(line, stopchar=None, lower=False, quotechars = '"\''):
+
+def splitquote(line, stopchar=None, lower=False, quotechars='"\''):
     """
     Fast LineSplitter
     """
@@ -156,7 +168,8 @@ def splitquote(line, stopchar=None, lower=False, quotechars = '"\''):
     i = 0
     while 1:
         try:
-            char = line[i]; i += 1
+            char = line[i]
+            i += 1
         except IndexError:
             break
         l = []
@@ -169,25 +182,29 @@ def splitquote(line, stopchar=None, lower=False, quotechars = '"\''):
                     stopchar = char
                     i -= 1
                     break
-                if char=='\\':
+                if char == '\\':
                     nofslashes += 1
                 else:
                     nofslashes = 0
                 l_append(char)
                 try:
-                    char = line[i]; i += 1
+                    char = line[i]
+                    i += 1
                 except IndexError:
                     break
-            if not l: continue
+            if not l:
+                continue
             item = ''.join(l)
-            if lower: item = item.lower()
+            if lower:
+                item = item.lower()
             items.append(item)
             continue
-        if char==stopchar:
+        if char == stopchar:
             # string starts with quotechar
             l_append(char)
             try:
-                char = line[i]; i += 1
+                char = line[i]
+                i += 1
             except IndexError:
                 if l:
                     item = String(''.join(l))
@@ -195,17 +212,18 @@ def splitquote(line, stopchar=None, lower=False, quotechars = '"\''):
                 break
         # else continued string
         while 1:
-            if char==stopchar and not nofslashes % 2:
+            if char == stopchar and not nofslashes % 2:
                 l_append(char)
                 stopchar = None
                 break
-            if char=='\\':
+            if char == '\\':
                 nofslashes += 1
             else:
                 nofslashes = 0
             l_append(char)
             try:
-                char = line[i]; i += 1
+                char = line[i]
+                i += 1
             except IndexError:
                 break
         if l:

--- a/src/fparser/splitline.py
+++ b/src/fparser/splitline.py
@@ -256,8 +256,7 @@ def splitparen(line, paren_open="([", paren_close=")]"):
     stack = []   # Stack keeping track of required closing brackets
 
     i = -1
-    for char in line:
-        i += 1
+    for i, char in enumerate(line):
         char = line[i]
         if char == "\\":
             num_backslashes = (num_backslashes+1) % 2

--- a/src/fparser/splitline.py
+++ b/src/fparser/splitline.py
@@ -237,10 +237,11 @@ def splitparen(line, paren_open="([", paren_close=")]"):
     Splits a line into top-level parenthesis and not-parenthesised
     parts. E.g.: "a( (1+2)*3) = b(x)" becomes:
     ["a", "( (1+2)*3)", " = b", "(x)"]
-    Line: the string to split.
-    paren_open/close: The characters that define the parentheses.
-    They must be matched in order: paren_open[x] is closed by
-    paren_close[x].
+    :param str line: the string to split.
+    :param str paren_open: The characters that define an open parentheses.
+    :param str paren_close: The characters that define a closing parentheses.
+    The paren_open and paren_close strings must be matched in order:
+    paren_open[x] is closed by paren_close[x].
     """
 
     assert len(paren_open) == len(paren_close)

--- a/src/fparser/splitline.py
+++ b/src/fparser/splitline.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 # Modified work Copyright (c) 2017 Science and Technology Facilities Council
+# Modified work Copyright (c) 2017 by J. Henrichs, Bureau of Meteorology
 # Original work Copyright (c) 1999-2008 Pearu Peterson
 
 # All rights reserved.
@@ -69,6 +70,7 @@ Defines LineSplitter and helper functions.
 
 Original Author: Pearu Peterson <pearu@cens.ioc.ee>
 First version created: May 2006
+
 -----
 """
 
@@ -91,8 +93,8 @@ __all__ = ['String', 'string_replace_map', 'splitquote', 'splitparen']
 _f2py_str_findall = re.compile(r"_F2PY_STRING_CONSTANT_\d+_").findall
 _is_name = re.compile(r'\w*\Z', re.I).match
 _is_simple_str = re.compile(r'\w*\Z', re.I).match
-_f2py_findall = re.compile(r'(_F2PY_STRING_CONSTANT_\d+_|F2PY_EXPR_TUPLE_\d+)'
-                           ).findall
+_f2py_findall = re.compile(
+    r'(_F2PY_STRING_CONSTANT_\d+_|F2PY_EXPR_TUPLE_\d+)').findall
 
 
 class string_replace_dict(dict):
@@ -240,6 +242,8 @@ def splitparen(line, paren_open="([", paren_close=")]"):
     :param str line: the string to split.
     :param str paren_open: The characters that define an open parentheses.
     :param str paren_close: The characters that define a closing parentheses.
+    :return: List of parenthesised and not-parenthesised parts
+    :rtype: list of str
     The paren_open and paren_close strings must be matched in order:
     paren_open[x] is closed by paren_close[x].
     """
@@ -247,17 +251,14 @@ def splitparen(line, paren_open="([", paren_close=")]"):
     assert len(paren_open) == len(paren_close)
 
     items = []   # Result list
-    i = 0        # Index of current character
-    num_backslashes = 0   # Counts consecutivre "\" characters
+    num_backslashes = 0   # Counts consecutive "\" characters
     # Empty if outside quotes, or set to the starting (and therefore
     # also the ending) quote character while reading text inside quotes.
     inside_quotes_char = ""
     start = 0    # Index of start of current part.
     stack = []   # Stack keeping track of required closing brackets
 
-    i = -1
-    for i, char in enumerate(line):
-        char = line[i]
+    for idx, char in enumerate(line):
         if char == "\\":
             num_backslashes = (num_backslashes+1) % 2
             continue
@@ -284,8 +285,8 @@ def splitparen(line, paren_open="([", paren_close=")]"):
         if pos > -1:
             if len(stack) == 0:
                 # New part starts:
-                items.append(line[start:i])
-                start = i
+                items.append(line[start:idx])
+                start = idx
             stack.append(paren_close[pos])
             continue
 
@@ -294,8 +295,8 @@ def splitparen(line, paren_open="([", paren_close=")]"):
             stack.pop()
             if len(stack) == 0:
                 # Found last closing bracket
-                items.append(ParenString(line[start:i+1]))
-                start = i+1
+                items.append(ParenString(line[start:idx+1]))
+                start = idx+1
 
     # Add any leftover characters as a separate item
     if start != len(line):

--- a/src/fparser/splitline.py
+++ b/src/fparser/splitline.py
@@ -258,6 +258,10 @@ def splitparen(line, paren_open="([", paren_close=")]"):
                 inside_quotes_char = ''
             continue
 
+        if char == "\'" or char == '"':
+            inside_quotes_char = char
+            continue
+
         pos = paren_open.find(char)
         if pos > -1:
             if len(stack) == 0:
@@ -279,20 +283,3 @@ def splitparen(line, paren_open="([", paren_close=")]"):
     if start != len(line):
         items.append(line[start:])
     return items
-
-
-def test():
-    splitter = LineSplitter('abc\\\' def"12\\"3""56"dfad\'a d\'')
-    l = [item for item in splitter]
-    assert l==['abc\\\' def','"12\\"3"','"56"','dfad','\'a d\''],repr(l)
-    assert splitter.quotechar is None
-    l,stopchar=splitquote('abc\\\' def"12\\"3""56"dfad\'a d\'')
-    assert l==['abc\\\' def','"12\\"3"','"56"','dfad','\'a d\''],repr(l)
-    assert stopchar is None
-
-    l = string_replace_map('a()')
-    print(l)
-    print('ok')
-
-if __name__ == '__main__':
-    test()

--- a/src/fparser/splitline.py
+++ b/src/fparser/splitline.py
@@ -250,7 +250,7 @@ def splitparen(line, paren_open="([", paren_close=")]"):
     i = 0        # Index of current character
     num_backslashes = 0   # Counts consecutivre "\" characters
     # Empty if outside quotes, or set to the starting (and therefore
-    # also the ending) character.
+    # also the ending) quote character while reading text inside quotes.
     inside_quotes_char = ""
     start = 0    # Index of start of current part.
     stack = []   # Stack keeping track of required closing brackets

--- a/src/fparser/tests/test_parser.py
+++ b/src/fparser/tests/test_parser.py
@@ -672,7 +672,6 @@ def test_integer():
     assert parse(Integer, 'integer a = 5') == 'INTEGER :: a = 5'
 
 
-@pytest.mark.xfail(reason="Constant array assignment not yet supported.")
 def test_const_array_decl():
     '''Tests declarations that set an initial value to an array.'''
     assert parse(Integer, 'integer a(1) = (/1/)') == \

--- a/src/fparser/tests/test_parser.py
+++ b/src/fparser/tests/test_parser.py
@@ -655,6 +655,7 @@ def test_integer():
     assert parse(Integer, 'integer*4 a ,b') == 'INTEGER*4 a, b'
     assert parse(Integer, 'integer*4 :: a ,b') == 'INTEGER*4 a, b'
     assert parse(Integer, 'integer*4 a(1,2)') == 'INTEGER*4 a(1,2)'
+    assert parse(Integer, 'integer*4 a(2*(1+2)-1)') == 'INTEGER*4 a(2*(1+2)-1)'
     assert parse(Integer, 'integer*4 :: a(1,2),b') == \
         'INTEGER*4 a(1,2), b'
     assert parse(Integer, 'integer*4 external :: a') == \
@@ -668,6 +669,22 @@ def test_integer():
     assert parse(Integer, 'integer(kind=2+2)') == 'INTEGER(KIND=2+2)'
     assert parse(Integer, 'integer(kind=f(4,5))') == \
         'INTEGER(KIND=f(4,5))'
+    assert parse(Integer, 'integer a = 5') == 'INTEGER :: a = 5'
+
+
+@pytest.mark.xfail(reason="Constant array assignment not yet supported.")
+def test_const_array_decl():
+    '''Tests declarations that set an initial value to an array.'''
+    assert parse(Integer, 'integer a(1) = (/1/)') == \
+        'INTEGER :: a(1) = (/1/)'
+    assert parse(Real, 'real a(3) = (/1.1, 2.2, 3.3/)') == \
+        'REAL :: a(3) = (/1.1, 2.2, 3.3/)'
+    assert parse(Logical, 'logical :: a(3) = (/true, false, true/)') == \
+        'LOGICAL :: a(3) = (/true, false, true/)'
+    assert parse(Integer, 'integer a(1) = [1]') == \
+        'INTEGER :: a(1) = [1]'
+    assert parse(Integer, 'integer a(3) = [1, 2, 3]') == \
+        'INTEGER :: a(3) = [1, 2, 3]'
 
 
 def test_logical():

--- a/src/fparser/tests/test_splitline.py
+++ b/src/fparser/tests/test_splitline.py
@@ -90,6 +90,12 @@ def test_splitparen():
     # pylint: disable=anomalous-backslash-in-string
     assert splitparen('a[b] = b[x,y(1)] b\((a)\)') == \
         ['a', '[b]', ' = b', '[x,y(1)]', ' b\\(', '(a)', '\\)']
+    assert splitparen('integer a(3) = (/"a", "b", "c"/)') == \
+        ['integer a', '(3)', ' = ', '(/"a", "b", "c"/)']
+    assert splitparen(
+        'character(len=40) :: a(3) = (/"a[),", ",b,[(", "c,][)("/)') == \
+        ['character', '(len=40)', ' :: a', '(3)', ' = ',
+         '(/"a[),", ",b,[(", "c,][)("/)']
     assert splitparen('integer a(3) = ["a", "b", "c"]') == \
         ['integer a', '(3)', ' = ', '["a", "b", "c"]']
     assert splitparen(

--- a/src/fparser/tests/test_splitline.py
+++ b/src/fparser/tests/test_splitline.py
@@ -106,7 +106,7 @@ def test_splitparen():
          '["a[),", ",b,[(", "c,][)("]']
     # pylint: disable=anomalous-backslash-in-string
     result = splitparen('a(1),b\\((2,3),c\\\((1)),c"("')
-    expected = ['a', '(1)', ',b\(', '(2,3)', ',c\\\\', '((1))', ',c"("']
+    expected = ['a', '(1)', ',b\\(', '(2,3)', ',c\\\\', '((1))', ',c"("']
     # pylint: enable=anomalous-backslash-in-string
     assert result == expected
     # Useful for debugging:

--- a/src/fparser/tests/test_splitline.py
+++ b/src/fparser/tests/test_splitline.py
@@ -83,6 +83,7 @@ def test_splitparen():
     # pylint: disable=anomalous-backslash-in-string
     assert splitparen('a(b) = b(x,y(1)) b\((a)\)') == \
         ['a', '(b)', ' = b', '(x,y(1))', ' b\\(', '(a)', '\\)']
+    # pylint: enable=anomalous-backslash-in-string
     assert splitparen('abc[1]') == ['abc', '[1]']
     assert splitparen('abc[1,2,3]') == ['abc', '[1,2,3]']
     assert splitparen('a[b] = b[x,y(1)] b((a))') == \
@@ -90,6 +91,7 @@ def test_splitparen():
     # pylint: disable=anomalous-backslash-in-string
     assert splitparen('a[b] = b[x,y(1)] b\((a)\)') == \
         ['a', '[b]', ' = b', '[x,y(1)]', ' b\\(', '(a)', '\\)']
+    # pylint: enable=anomalous-backslash-in-string
     assert splitparen('integer a(3) = (/"a", "b", "c"/)') == \
         ['integer a', '(3)', ' = ', '(/"a", "b", "c"/)']
     assert splitparen(
@@ -102,31 +104,36 @@ def test_splitparen():
         'character(len=40) :: a(3) = ["a[),", ",b,[(", "c,][)("]') == \
         ['character', '(len=40)', ' :: a', '(3)', ' = ',
          '["a[),", ",b,[(", "c,][)("]']
-    l = splitparen('a(1),b\\((2,3),c\\\((1)),c"("')
-    EXPECTED=['a', '(1)', ',b\(', '(2,3)', ',c\\\\', '((1))', ',c"("']
-    assert l==EXPECTED
+    # pylint: disable=anomalous-backslash-in-string
+    result = splitparen('a(1),b\\((2,3),c\\\((1)),c"("')
+    expected = ['a', '(1)', ',b\(', '(2,3)', ',c\\\\', '((1))', ',c"("']
+    # pylint: enable=anomalous-backslash-in-string
+    assert result == expected
     # Useful for debugging:
     # for i in range(len(EXPECTED)):
     #     print i,l[i],EXPECTED[i],l[i]==EXPECTED[i]
 
 
 def test_splitquote():
+    '''Tests splitquote function.'''
     split_list, stopchar = splitquote('abc\\\' def"12\\"3""56"dfad\'a d\'')
-    assert split_list==['abc\\\' def','"12\\"3"','"56"','dfad','\'a d\'']
+    assert split_list == ['abc\\\' def', '"12\\"3"', '"56"', 'dfad', '\'a d\'']
     assert stopchar is None
-    l,stopchar=splitquote('abc\\\' def"12\\"3""56"dfad\'a d\'')
-    assert l==['abc\\\' def','"12\\"3"','"56"','dfad','\'a d\''],repr(l)
+    result, stopchar = splitquote('abc\\\' def"12\\"3""56"dfad\'a d\'')
+    assert result == ['abc\\\' def', '"12\\"3"', '"56"', 'dfad', '\'a d\'']
     assert stopchar is None
 
     split_list, stopchar = splitquote('a\'')
-    assert split_list==['a', '\'']
+    assert split_list == ['a', '\'']
     assert stopchar == '\''
 
     split_list, stopchar = splitquote('a\'b')
-    assert split_list==['a', '\'b']
-    assert stopchar =='\''
+    assert split_list == ['a', '\'b']
+    assert stopchar == '\''
 
 
-    l, string_map = string_replace_map('a()')
-    assert l=='a()'
+def test_string_replace_map():
+    '''Tests string_replace_map function.'''
+    result, string_map = string_replace_map('a()')
+    assert result == 'a()'
     assert string_map == {}

--- a/src/fparser/tests/test_splitline.py
+++ b/src/fparser/tests/test_splitline.py
@@ -105,7 +105,7 @@ def test_splitparen():
         ['character', '(len=40)', ' :: a', '(3)', ' = ',
          '["a[),", ",b,[(", "c,][)("]']
     # pylint: disable=anomalous-backslash-in-string
-    result = splitparen('a(1),b\\((2,3),c\\\((1)),c"("')
+    result = splitparen('a(1),b\\((2,3),c\\\\((1)),c"("')
     expected = ['a', '(1)', ',b\\(', '(2,3)', ',c\\\\', '((1))', ',c"("']
     # pylint: enable=anomalous-backslash-in-string
     assert result == expected

--- a/src/fparser/tests/test_splitline.py
+++ b/src/fparser/tests/test_splitline.py
@@ -64,6 +64,7 @@
 
 # Original author: Pearu Peterson <pearu@cens.ioc.ee>
 # First version created: May 2006
+# Modified by J. Henrichs, Bureau of Meteorology <joerg.henrichs@bom.gov.au>
 
 """
 Test parsing single Fortran lines.

--- a/src/fparser/tests/test_splitline.py
+++ b/src/fparser/tests/test_splitline.py
@@ -70,8 +70,6 @@ Test parsing single Fortran lines.
 
 """
 
-import pytest
-
 from fparser.splitline import splitparen
 
 
@@ -79,16 +77,12 @@ def test_splitparen():
     ''' Unit tests for splitparen function.'''
     assert splitparen('abc') == ['abc']
     assert splitparen('abc(1)') == ['abc', '(1)']
+    assert splitparen('abc(1) xyz') == ['abc', '(1)', ' xyz']
     assert splitparen('a(b) = b(x,y(1)) b((a))') == \
         ['a', '(b)', ' = b', '(x,y(1))', ' b', '((a))']
     # pylint: disable=anomalous-backslash-in-string
     assert splitparen('a(b) = b(x,y(1)) b\((a)\)') == \
         ['a', '(b)', ' = b', '(x,y(1))', ' b\\(', '(a)', '\\)']
-
-
-@pytest.mark.xfail(reason="Square brackets not yet supported.")
-def test_splitparen_xfail():
-    ''' Currently failing unit tests for splitparen function - wip.'''
     assert splitparen('abc[1]') == ['abc', '[1]']
     assert splitparen('abc[1,2,3]') == ['abc', '[1,2,3]']
     assert splitparen('a[b] = b[x,y(1)] b((a))') == \
@@ -96,3 +90,9 @@ def test_splitparen_xfail():
     # pylint: disable=anomalous-backslash-in-string
     assert splitparen('a[b] = b[x,y(1)] b\((a)\)') == \
         ['a', '[b]', ' = b', '[x,y(1)]', ' b\\(', '(a)', '\\)']
+    assert splitparen('integer a(3) = ["a", "b", "c"]') == \
+        ['integer a', '(3)', ' = ', '["a", "b", "c"]']
+    assert splitparen(
+        'character(len=40) :: a(3) = ["a[),", ",b,[(", "c,][)("]') == \
+        ['character', '(len=40)', ' :: a', '(3)', ' = ',
+         '["a[),", ",b,[(", "c,][)("]']

--- a/src/fparser/tests/test_splitline.py
+++ b/src/fparser/tests/test_splitline.py
@@ -1,0 +1,98 @@
+# Modified work Copyright (c) 2017 Science and Technology Facilities Council
+# Original work Copyright (c) 1999-2008 Pearu Peterson
+
+# All rights reserved.
+
+# Modifications made as part of the fparser project are distributed
+# under the following license:
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# --------------------------------------------------------------------
+
+# The original software (in the f2py project) was distributed under
+# the following license:
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+#   a. Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+#   b. Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#   c. Neither the name of the F2PY project nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+
+# Original author: Pearu Peterson <pearu@cens.ioc.ee>
+# First version created: May 2006
+
+"""
+Test parsing single Fortran lines.
+
+"""
+
+import pytest
+
+from fparser.splitline import splitparen
+
+
+def test_splitparen():
+    ''' Unit tests for splitparen function.'''
+    assert splitparen('abc') == ['abc']
+    assert splitparen('abc(1)') == ['abc', '(1)']
+    assert splitparen('a(b) = b(x,y(1)) b((a))') == \
+        ['a', '(b)', ' = b', '(x,y(1))', ' b', '((a))']
+    # pylint: disable=anomalous-backslash-in-string
+    assert splitparen('a(b) = b(x,y(1)) b\((a)\)') == \
+        ['a', '(b)', ' = b', '(x,y(1))', ' b\\(', '(a)', '\\)']
+
+
+@pytest.mark.xfail(reason="Square brackets not yet supported.")
+def test_splitparen_xfail():
+    ''' Currently failing unit tests for splitparen function - wip.'''
+    assert splitparen('abc[1]') == ['abc', '[1]']
+    assert splitparen('abc[1,2,3]') == ['abc', '[1,2,3]']
+    assert splitparen('a[b] = b[x,y(1)] b((a))') == \
+        ['a', '[b]', ' = b', '[x,y(1)]', ' b', '((a))']
+    # pylint: disable=anomalous-backslash-in-string
+    assert splitparen('a[b] = b[x,y(1)] b\((a)\)') == \
+        ['a', '[b]', ' = b', '[x,y(1)]', ' b\\(', '(a)', '\\)']

--- a/src/fparser/tests/test_splitline.py
+++ b/src/fparser/tests/test_splitline.py
@@ -70,7 +70,7 @@ Test parsing single Fortran lines.
 
 """
 
-from fparser.splitline import splitparen
+from fparser.splitline import splitparen, splitquote, string_replace_map
 
 
 def test_splitparen():
@@ -102,3 +102,31 @@ def test_splitparen():
         'character(len=40) :: a(3) = ["a[),", ",b,[(", "c,][)("]') == \
         ['character', '(len=40)', ' :: a', '(3)', ' = ',
          '["a[),", ",b,[(", "c,][)("]']
+    l = splitparen('a(1),b\\((2,3),c\\\((1)),c"("')
+    EXPECTED=['a', '(1)', ',b\(', '(2,3)', ',c\\\\', '((1))', ',c"("']
+    assert l==EXPECTED
+    # Useful for debugging:
+    # for i in range(len(EXPECTED)):
+    #     print i,l[i],EXPECTED[i],l[i]==EXPECTED[i]
+
+
+def test_splitquote():
+    split_list, stopchar = splitquote('abc\\\' def"12\\"3""56"dfad\'a d\'')
+    assert split_list==['abc\\\' def','"12\\"3"','"56"','dfad','\'a d\'']
+    assert stopchar is None
+    l,stopchar=splitquote('abc\\\' def"12\\"3""56"dfad\'a d\'')
+    assert l==['abc\\\' def','"12\\"3"','"56"','dfad','\'a d\''],repr(l)
+    assert stopchar is None
+
+    split_list, stopchar = splitquote('a\'')
+    assert split_list==['a', '\'']
+    assert stopchar == '\''
+
+    split_list, stopchar = splitquote('a\'b')
+    assert split_list==['a', '\'b']
+    assert stopchar =='\''
+
+
+    l, string_map = string_replace_map('a()')
+    assert l=='a()'
+    assert string_map == {}


### PR DESCRIPTION
Hi,

this fixes lines like "integer a(3) = [1,2,3]". The parser didn't like the [] ('(/ /)' worked), and I also improved handling of quotes in case of assignment of arrays of strings.