### PR TITLE
Improve "source info" functions and add testing

### DIFF
--- a/src/fparser/readfortran.py
+++ b/src/fparser/readfortran.py
@@ -1252,8 +1252,9 @@ class FortranStringReader(FortranReaderBase):
     def __init__(self, string, include_dirs = None, source_only = None):
         self.id = 'string-'+str(id(string))
         source = six.StringIO(string)
-        isfree, isstrict = get_source_info_str(string)
-        FortranReaderBase.__init__(self, source, isfree, isstrict)
+        format = get_source_info_str(string)
+        FortranReaderBase.__init__(self, source,
+                                   format.is_free(), format.is_strict())
         if include_dirs is not None:
             self.include_dirs = include_dirs[:]
         if source_only is not None:

--- a/src/fparser/readfortran.py
+++ b/src/fparser/readfortran.py
@@ -1232,10 +1232,11 @@ class FortranReaderBase(object):
 class FortranFileReader(FortranReaderBase):
 
     def __init__(self, filename, include_dirs = None, source_only=None):
-        isfree, isstrict = get_source_info(filename)
+        format = get_source_info(filename)
         self.id = filename
         self.file = open(filename,'r')
-        FortranReaderBase.__init__(self, self.file, isfree, isstrict)
+        FortranReaderBase.__init__(self, self.file,
+                                   format.is_free(), format.is_strict())
         if include_dirs is None:
             self.include_dirs.insert(0, os.path.dirname(filename))
         else:

--- a/src/fparser/readfortran.py
+++ b/src/fparser/readfortran.py
@@ -1236,7 +1236,7 @@ class FortranFileReader(FortranReaderBase):
         self.id = filename
         self.file = open(filename,'r')
         FortranReaderBase.__init__(self, self.file,
-                                   format.is_free(), format.is_strict())
+                                   format.is_free, format.is_strict)
         if include_dirs is None:
             self.include_dirs.insert(0, os.path.dirname(filename))
         else:
@@ -1255,7 +1255,7 @@ class FortranStringReader(FortranReaderBase):
         source = six.StringIO(string)
         format = get_source_info_str(string)
         FortranReaderBase.__init__(self, source,
-                                   format.is_free(), format.is_strict())
+                                   format.is_free, format.is_strict)
         if include_dirs is not None:
             self.include_dirs = include_dirs[:]
         if source_only is not None:

--- a/src/fparser/sourceinfo.py
+++ b/src/fparser/sourceinfo.py
@@ -100,7 +100,7 @@ class FortranFormat(object):
                    and self._is_strict == other.is_strict
         raise NotImplementedError
 
-    def __repr__(self):
+    def __str__(self):
         if self._is_strict:
             string = 'Strict'
         else:

--- a/src/fparser/sourceinfo.py
+++ b/src/fparser/sourceinfo.py
@@ -68,8 +68,9 @@ fixed format. It also tries to differentiate between strict and "pyf" although
 I'm not sure what that is.
 '''
 
-import re
 import os
+import re
+import six
 
 
 ##############################################################################
@@ -199,8 +200,7 @@ def get_source_info(file_candidate):
         # Under Python 2 file.name holds a string of the form "<..>".
         elif filename.startswith('<') and filename.endswith('>'):
             filename = None
-    elif isinstance(file_candidate,
-                    str) or isinstance(file_candidate, basestring):
+    elif isinstance(file_candidate, six.string_types):
         # The preferred method for identifying strings changed between Python2
         # and Python3.
         filename = file_candidate

--- a/src/fparser/sourceinfo.py
+++ b/src/fparser/sourceinfo.py
@@ -62,21 +62,11 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
 
-"""
-Provides get_source_info(<filename>) function to determine the format
-(free|fixed|strict|pyf) of a Fortran file.
-
------
-Permission to use, modify, and distribute this software is given under the
-terms of the NumPy License. See http://scipy.org.
-
-NO WARRANTY IS EXPRESSED OR IMPLIED.  USE AT YOUR OWN RISK.
-Author: Pearu Peterson <pearu@cens.ioc.ee>
-Created: May 2006
------
-"""
-
-__all__ = ['get_source_info', 'get_source_info_str']
+'''
+Provides functions to determine whether a piece of Fortran source is free or
+fixed format. It also tries to differentiate between strict and "pyf" although
+I'm not sure what that is.
+'''
 
 import re
 import os
@@ -91,6 +81,72 @@ _has_free_header = re.compile(r'-[*]-\s*(f90|f95|f03|f08)\s*-[*]-',re.I).search
 _has_fix_header = re.compile(r'-[*]-\s*fix\s*-[*]-',re.I).search
 _has_pyf_header = re.compile(r'-[*]-\s*pyf\s*-[*]-',re.I).search
 _free_format_start = re.compile(r'[^c*!]\s*[^\s\d\t]',re.I).match
+
+##############################################################################
+
+class FortranFormat(object):
+    def __init__( self, is_free, is_strict ):
+        self._is_free   = is_free
+        self._is_strict    = is_strict
+
+    def __eq__(self, other):
+        if isinstance( other, FortranFormat):
+            return self._is_free == other._is_free \
+                   and self._is_strict == other._is_strict
+        raise NotImplemented
+
+    def __repr__(self):
+        if self._is_strict:
+            string = 'Strict'
+        else:
+            string = 'Non-strict'
+
+        if self._is_free:
+            string += ' free'
+        else:
+            string += ' fixed'
+
+        return string + ' format'
+
+    def is_free( self ):
+        return self._is_free
+
+    def is_strict( self ):
+        return self._is_strict
+
+##############################################################################
+
+def get_source_info_str( source ):
+    '''
+    Determines the format of Fortran source held in a string.
+
+    Returns a FortranFormat object.
+    '''
+
+    lines = source.splitlines()
+    if not lines:
+        return FortranFormat(False, False)
+
+    firstline = lines[0].lstrip()
+    if _has_f_header(firstline):    return FortranFormat(False, True)
+    if _has_fix_header(firstline):  return FortranFormat(False, False)
+    if _has_free_header(firstline): return FortranFormat(True,  False)
+    if _has_pyf_header(firstline):  return FortranFormat(True,  True)
+
+    n = 10000 # Check up to this number of non-comment lines for hints.
+    is_free = False
+    while n>0 and lines:
+        line = lines.pop(0).rstrip()
+        if line and line[0] != '!':
+            n -= 1
+            if line[0] != '\t' and _free_format_start(line[:5]) \
+               or line[-1:] == '&':
+                is_free = True
+                break
+
+    return FortranFormat(is_free, False)
+
+##############################################################################
 
 def get_source_info(filename):
     """
@@ -108,39 +164,16 @@ def get_source_info(filename):
     f = open(filename,'r')
     firstline = f.readline()
     f.close()
-    if _has_f_header(firstline): return False, True
-    if _has_fix_header(firstline): return False, False
-    if _has_free_header(firstline): return True, False
-    if _has_pyf_header(firstline): return True, True
+    if _has_f_header(firstline):    return False, True
+    if _has_fix_header(firstline):  return False, True
+    if _has_free_header(firstline): return True,  False
+    if _has_pyf_header(firstline):  return True,  True
     if _has_f_extension(filename) and \
        not (_has_free_header(firstline) or _has_fix_header(firstline)):
         isstrict = True
     elif is_free_format(filename) and not _has_fix_header(firstline):
         isfree = True
     return isfree,isstrict
-
-def get_source_info_str(code):
-    """
-    Determine the format of Fortran code.
-    See get_source_info() for the meaning of return values.
-    """
-    firstline = code.lstrip().split('\n',1)[0]
-    if _has_f_header(firstline): return False, True
-    if _has_fix_header(firstline): return False, False
-    if _has_free_header(firstline): return True, False
-    if _has_pyf_header(firstline): return True, True
-    n = 10000 # the number of non-comment lines to scan for hints
-    lines = code.splitlines()
-    isfree = False
-    while n>0 and lines:
-        line = lines.pop(0).rstrip()
-        if line and line[0]!='!':
-            n -= 1
-            if line[0]!='\t' and _free_format_start(line[:5]) or line[-1:]=='&':
-                isfree = True
-                break
-        
-    return isfree, False # assume free f90 or fix f90.
 
 def is_free_format(file):
     """Check if file is in free format Fortran."""

--- a/src/fparser/sourceinfo.py
+++ b/src/fparser/sourceinfo.py
@@ -186,7 +186,7 @@ def get_source_info(file_candidate):
 
     Returns a FortranFormat object.
     '''
-    if hasattr(file_candidate, 'name'):
+    if hasattr(file_candidate, 'name') and hasattr(file_candidate, 'read'):
         filename = file_candidate.name
 
         # The behaviour of file.name when associated with a file without a
@@ -199,8 +199,14 @@ def get_source_info(file_candidate):
         # Under Python 2 file.name holds a string of the form "<..>".
         elif filename.startswith('<') and filename.endswith('>'):
             filename = None
-    else:  # Candidate is a filename
+    elif isinstance(file_candidate,
+                    str) or isinstance(file_candidate, basestring):
+        # The preferred method for identifying strings changed between Python2
+        # and Python3.
         filename = file_candidate
+    else:
+        message = 'Argument must be a file or filename.'
+        raise ValueError(message)
 
     if filename:
         _, ext = os.path.splitext(filename)
@@ -221,8 +227,11 @@ def get_source_info(file_candidate):
         file_candidate.seek(pointer)
         return source_info
     else:
-        # No "read" method so presumably it's a filename string. In which case
-        # we need to open the named file so we can read it.
+        # It isn't a file and it passed the type check above so it must be
+        # a string.
+        #
+        # If it's a string we assume it is a filename. In which case we need
+        # to open the named file so we can read it.
         #
         # It is closed on completion so as to return it to the state it was
         # found in.

--- a/src/fparser/sourceinfo.py
+++ b/src/fparser/sourceinfo.py
@@ -188,6 +188,7 @@ def get_source_info(file_candidate):
     '''
     if hasattr(file_candidate, 'name'):
         filename = file_candidate.name
+
         # The behaviour of file.name when associated with a file without a
         # file name has changed between Python 2 and 3.
         #
@@ -207,12 +208,25 @@ def get_source_info(file_candidate):
             return FortranFormat(True, True)
 
     if hasattr(file_candidate, 'read'):
+        # If the candidate object has a "read" method we assume it's a file
+        # object.
+        #
+        # If it is a file object then it may be in the process of being read.
+        # As such we need to take a note of the current state of the file
+        # pointer so we can restore it when we've finished what we're doing.
+        #
         pointer = file_candidate.tell()
         file_candidate.seek(0)
         source_info = get_source_info_str(file_candidate.read())
         file_candidate.seek(pointer)
         return source_info
     else:
+        # No "read" method so presumably it's a filename string. In which case
+        # we need to open the named file so we can read it.
+        #
+        # It is closed on completion so as to return it to the state it was
+        # found in.
+        #
         with open(file_candidate, 'r') as file_object:
             return get_source_info_str(file_object.read())
 

--- a/src/fparser/sourceinfo.py
+++ b/src/fparser/sourceinfo.py
@@ -79,16 +79,25 @@ class FortranFormat(object):
     Describes the nature of a piece of Fortran source.
 
     Source can be fixed or free format. It can also be "strict" or
-    "not strict" although it's not entirely clear what that means.
+    "not strict" although it's not entirely clear what that means. It may
+    refer to the strictness of adherance to fixed format although what that
+    means in the context of free format I don't know.
     '''
     def __init__(self, is_free, is_strict):
+        '''
+        Constructs a FortranFormat object from the describing parameters.
+
+        Arguments:
+            is_free   - (Boolean) True for free format, False for fixed.
+            is_strict - (Boolean) Some amount of strictness.
+        '''
         self._is_free = is_free
         self._is_strict = is_strict
 
     def __eq__(self, other):
         if isinstance(other, FortranFormat):
-            return self._is_free == other.is_free() \
-                   and self._is_strict == other.is_strict()
+            return self._is_free == other.is_free \
+                   and self._is_strict == other.is_strict
         raise NotImplementedError
 
     def __repr__(self):
@@ -104,12 +113,14 @@ class FortranFormat(object):
 
         return string + ' format'
 
+    @property
     def is_free(self):
         '''
         Returns true if the "free format" flag is set.
         '''
         return self._is_free
 
+    @property
     def is_strict(self):
         '''
         Returns true if the "strict" flag is set.

--- a/src/fparser/sourceinfo.py
+++ b/src/fparser/sourceinfo.py
@@ -176,12 +176,18 @@ def get_source_info(file_candidate):
     Returns a FortranFormat object.
     '''
     if hasattr(file_candidate, 'name'):
-        if file_candidate.name.startswith('<') \
-           and file_candidate.name.endswith('>'):
+        filename = file_candidate.name
+        # The behaviour of file.name when associated with a file without a
+        # file name has changed between Python 2 and 3.
+        #
+        # Under Python 3 file.name holds an integer file handle.
+        if isinstance(filename, int):
             filename = None
-        else:  # It's an actual file.
-            filename = file_candidate.name
-    else:  # It's a filename
+
+        # Under Python 2 file.name holds a string of the form "<..>".
+        elif filename.startswith('<') and filename.endswith('>'):
+            filename = None
+    else:  # Candidate is a filename
         filename = file_candidate
 
     if filename:

--- a/src/fparser/sourceinfo.py
+++ b/src/fparser/sourceinfo.py
@@ -122,7 +122,6 @@ def get_source_info_str( source ):
 
     Returns a FortranFormat object.
     '''
-
     lines = source.splitlines()
     if not lines:
         return FortranFormat(False, False)
@@ -148,61 +147,25 @@ def get_source_info_str( source ):
 
 ##############################################################################
 
-def get_source_info(filename):
-    """
-    Determine if fortran file is
-      - in fix format and contains Fortran 77 code    -> return False, True
-      - in fix format and contains Fortran 90,95,2003,2008 code    -> return False, False
-      - in free format and contains Fortran 90,95,2003,2008 code   -> return True, False
-      - in free format and contains signatures (.pyf) -> return True, True
-    """
-    base,ext = os.path.splitext(filename)
-    if ext=='.pyf':
-        return True, True
-    isfree = False
-    isstrict = False
-    f = open(filename,'r')
-    firstline = f.readline()
-    f.close()
-    if _has_f_header(firstline):    return False, True
-    if _has_fix_header(firstline):  return False, True
-    if _has_free_header(firstline): return True,  False
-    if _has_pyf_header(firstline):  return True,  True
-    if _has_f_extension(filename) and \
-       not (_has_free_header(firstline) or _has_fix_header(firstline)):
-        isstrict = True
-    elif is_free_format(filename) and not _has_fix_header(firstline):
-        isfree = True
-    return isfree,isstrict
+def get_source_info(file_candidate):
+    '''
+    Determines the format of Fortran source held in a file.
 
-def is_free_format(file):
-    """Check if file is in free format Fortran."""
-    # f90-2008 allows both fixed and free format, assuming fixed
-    # unless signs of free format are detected.
-    isfree = False
-    f = open(file,'r')
-    line = f.readline()
-    n = 10000 # the number of non-comment lines to scan for hints
-    if _has_f_header(line):
-        n = 0
-    elif _has_free_header(line):
-        n = 0
-        isfree = True
-    while n>0 and line:
-        line = line.rstrip()
-        if line and line[0]!='!':
-            n -= 1
-            if line[0]!='\t' and _free_format_start(line[:5]) or line[-1:]=='&':
-                isfree = True
-                break
-        line = f.readline()
-    f.close()
-    return isfree
+    Returns a FortranFormat object.
+    '''
+    if hasattr(file_candidate, 'name'):
+        base, ext = os.path.splitext(file_candidate)
+        if ext == '.pyf':
+            return FortranFormat(True, True)
 
-def simple_main():
-    for filename in sys.argv[1:]:
-        isfree, isstrict = get_source_info(filename)
-        print('%s: isfree=%s, isstrict=%s'  % (filename, isfree, isstrict))
+    if hasattr(file_candidate, 'read'):
+        pointer = file_candidate.tell()
+        file_candidate.seek(0)
+        return get_source_info_str(file_candidate.read())
+        file_candidate.seek(pointer)
+    else:
+        with open(file_candidate, 'r') as file_object:
+            return get_source_info_str(file_object.read())
 
-if __name__ == '__main__':
-    simple_main()
+
+##############################################################################

--- a/src/fparser/tests/test_sourceinfo.py
+++ b/src/fparser/tests/test_sourceinfo.py
@@ -50,6 +50,26 @@ from fparser.sourceinfo import FortranFormat, \
 
 
 ##############################################################################
+@pytest.fixture(scope="module",
+                params=[(False, False, 'Non-strict fixed format'),
+                        (False, True, 'Strict fixed format'),
+                        (True, False, 'Non-strict free format'),
+                        (True, True, 'Strict free format')])
+def format(request):
+    '''
+    Returns parameters for format tests.
+    '''
+    return request.param
+
+
+##############################################################################
+
+def test_FortranFormat(format):
+    unit_under_test = FortranFormat(format[0], format[1])
+    assert str(unit_under_test) == format[2]
+
+
+##############################################################################
 # Setting up a pytest fixture in this way is a mechanism for creating
 # parameterised tests.
 #

--- a/src/fparser/tests/test_sourceinfo.py
+++ b/src/fparser/tests/test_sourceinfo.py
@@ -106,7 +106,7 @@ def test_fortranformat_invalid():
     and oranges.
     '''
     unit_under_test = FortranFormat(True, False)
-    with pytest.raises(Exception):
+    with pytest.raises(NotImplementedError):
         if unit_under_test == 'oranges':
             raise Exception("That shouldn't have happened")
 

--- a/src/fparser/tests/test_sourceinfo.py
+++ b/src/fparser/tests/test_sourceinfo.py
@@ -64,7 +64,10 @@ def pretty(request):
 
 ##############################################################################
 
-def test_FortranFormat_string(pretty):
+def test_fortranformat_string(pretty):
+    '''
+    Tests for the correct string representations.
+    '''
     unit_under_test = FortranFormat(pretty[0], pretty[1])
     assert str(unit_under_test) == pretty[2]
 
@@ -84,9 +87,12 @@ def permutations(request):
 
 ##############################################################################
 
-def test_FortranFormat_equality(permutations, pretty):
+def test_fortranformat_equality(permutations, pretty):
+    '''
+    Tests that the equality operator works as expected.
+    '''
     expected = (permutations[0] == pretty[0]) \
-               and (permutations[1] == pretty[1])
+        and (permutations[1] == pretty[1])
     unit_under_test = FortranFormat(permutations[0], permutations[1])
     candidate = FortranFormat(pretty[0], pretty[1])
     assert (unit_under_test == candidate) == expected

--- a/src/fparser/tests/test_sourceinfo.py
+++ b/src/fparser/tests/test_sourceinfo.py
@@ -61,6 +61,9 @@ from fparser.sourceinfo import FortranFormat, \
 # argument list will be run once with "header" equal to "! -*- fortran -*-",
 # then with "header" equal to "! -*- f77 -*-" and so on.
 #
+# If a test includes multiple parameter fixtures it will be called for every
+# permutation thus afforded.
+#
 @pytest.fixture(scope="module",
                 params=[(None, FortranFormat(True, True)),
                         ("! -*- fortran -*-", FortranFormat(False, True)),

--- a/src/fparser/tests/test_sourceinfo.py
+++ b/src/fparser/tests/test_sourceinfo.py
@@ -42,17 +42,17 @@ Test battery associated with fparser.sourceinfo package.
 from __future__ import print_function
 
 import pytest
-import fparser.sourceinfo
+from fparser.sourceinfo import FortranFormat, get_source_info_str
 
 @pytest.fixture(scope="module",
-                params=[('', True, True),
-                        ("-*- fortran -*-", False, True),
-                        ("-*- f77 -*-",     False, True),
-                        ('-*- f90 -*-',     True,  False),
-                        ('-*- f03 -*-',     True,  False),
-                        ('-*- f08 -*-',     True,  False),
-                        ('-*- fix -*-',     False, False),
-                        ('-*- pyf -*-',     True,  True)])
+                params=[('', FortranFormat(True, True)),
+                        ("-*- fortran -*-", FortranFormat(False, True)),
+                        ("-*- f77 -*-",     FortranFormat(False, True)),
+                        ('-*- f90 -*-',     FortranFormat(True,  False)),
+                        ('-*- f03 -*-',     FortranFormat(True,  False)),
+                        ('-*- f08 -*-',     FortranFormat(True,  False)),
+                        ('-*- fix -*-',     FortranFormat(False, False)),
+                        ('-*- pyf -*-',     FortranFormat(True,  True))])
 def header(request):
     return request.param
 
@@ -64,7 +64,7 @@ _free_source = '''program main
 end program main
 '''
 
-_fixed_with_continuation = '''      program main
+_fixed_with_continue = '''      program main
           implicit none
           integer :: foo, &
                      bar
@@ -88,21 +88,20 @@ _initial_tab = "\tprogram main\n"
 _middle_tab = " \tprogram main\n"
 
 @pytest.fixture(scope="module",
-                params=[(_fixed_source,            False, False),
-                        (_free_source,             True,  False),
-                        (_fixed_with_continuation, True,  False),
-                        (_fixed_with_comments,     False, False),
-                        (_initial_tab,             False, False),
-                        (_middle_tab,              True,  False)])
+                params=[('',                   FortranFormat(False, False)),
+                        (_fixed_source,        FortranFormat(False, False)),
+                        (_free_source,         FortranFormat(True,  False)),
+                        (_fixed_with_continue, FortranFormat(True,  False)),
+                        (_fixed_with_comments, FortranFormat(False, False)),
+                        (_initial_tab,         FortranFormat(False, False)),
+                        (_middle_tab,          FortranFormat(True,  False))])
 def content(request):
     return request.param
 
 def test_get_source_info_str(header, content):
     full_source = header[0] + '\n' + content[0]
-    fixed, strict = fparser.sourceinfo.get_source_info_str(full_source)
+    format = get_source_info_str(full_source)
     if header[0]:
-      assert fixed  == header[1]
-      assert strict == header[2]
+      assert format == header[1]
     else: # No header
-      assert fixed  == content[1]
-      assert strict == content[2]
+      assert format == content[1]

--- a/src/fparser/tests/test_sourceinfo.py
+++ b/src/fparser/tests/test_sourceinfo.py
@@ -55,7 +55,7 @@ from fparser.sourceinfo import FortranFormat, \
                         (False, True, 'Strict fixed format'),
                         (True, False, 'Non-strict free format'),
                         (True, True, 'Strict free format')])
-def format(request):
+def pretty(request):
     '''
     Returns parameters for format tests.
     '''
@@ -64,9 +64,32 @@ def format(request):
 
 ##############################################################################
 
-def test_FortranFormat(format):
-    unit_under_test = FortranFormat(format[0], format[1])
-    assert str(unit_under_test) == format[2]
+def test_FortranFormat_string(pretty):
+    unit_under_test = FortranFormat(pretty[0], pretty[1])
+    assert str(unit_under_test) == pretty[2]
+
+
+##############################################################################
+@pytest.fixture(scope="module",
+                params=[(False, False),
+                        (False, True),
+                        (True, False),
+                        (True, True)])
+def permutations(request):
+    '''
+    Returns all possible permutations of the input arguments.
+    '''
+    return request.param
+
+
+##############################################################################
+
+def test_FortranFormat_equality(permutations, pretty):
+    expected = (permutations[0] == pretty[0]) \
+               and (permutations[1] == pretty[1])
+    unit_under_test = FortranFormat(permutations[0], permutations[1])
+    candidate = FortranFormat(pretty[0], pretty[1])
+    assert (unit_under_test == candidate) == expected
 
 
 ##############################################################################

--- a/src/fparser/tests/test_sourceinfo.py
+++ b/src/fparser/tests/test_sourceinfo.py
@@ -99,6 +99,18 @@ def test_fortranformat_equality(permutations, pretty):
 
 
 ##############################################################################
+
+def test_fortranformat_invalid():
+    '''
+    Tests that the equality operator understands that it can't compare apples
+    and oranges.
+    '''
+    unit_under_test = FortranFormat(True, False)
+    with pytest.raises(Exception):
+        unit_under_test == 'oranges'
+
+
+##############################################################################
 # Setting up a pytest fixture in this way is a mechanism for creating
 # parameterised tests.
 #

--- a/src/fparser/tests/test_sourceinfo.py
+++ b/src/fparser/tests/test_sourceinfo.py
@@ -50,7 +50,17 @@ from fparser.sourceinfo import FortranFormat, \
 
 
 ##############################################################################
-
+# Setting up a pytest fixture in this way is a mechanism for creating
+# parameterised tests.
+#
+# Normally when a test includes a fixture in its argument list the
+# corresponding function will be called and the result passed in to the test.
+#
+# When used like this the test will be called once for each value the fixture
+# function returns. So in this case any test including "header" in its
+# argument list will be run once with "header" equal to "! -*- fortran -*-",
+# then with "header" equal to "! -*- f77 -*-" and so on.
+#
 @pytest.fixture(scope="module",
                 params=[(None, FortranFormat(True, True)),
                         ("! -*- fortran -*-", FortranFormat(False, True)),
@@ -101,6 +111,8 @@ _INITIAL_TAB = "\tprogram main\n"
 _MIDDLE_TAB = " \tprogram main\n"
 
 
+# Another parameterised test fixture. See "header" above.
+#
 @pytest.fixture(scope="module",
                 params=[(None, FortranFormat(False, False)),
                         (_FIXED_SOURCE, FortranFormat(False, False)),
@@ -137,6 +149,8 @@ def test_get_source_info_str(header, content):
 
 ##############################################################################
 
+# Another parameterised test fixture. See "header" above.
+#
 @pytest.fixture(scope="module",
                 params=[('.f', None),
                         ('.f90', None),

--- a/src/fparser/tests/test_sourceinfo.py
+++ b/src/fparser/tests/test_sourceinfo.py
@@ -227,8 +227,8 @@ def extension(request):
     '''
     return request.param
 
-##############################################################################
 
+##############################################################################
 
 def test_get_source_info_filename(extension, header, content):
     '''
@@ -258,8 +258,8 @@ def test_get_source_info_filename(extension, header, content):
         os.remove(filename)
         raise ex
 
-##############################################################################
 
+##############################################################################
 
 def test_get_source_info_file(extension, header, content):
     '''
@@ -281,5 +281,19 @@ def test_get_source_info_file(extension, header, content):
             assert source_info == header[1]
         else:  # No header
             assert source_info == content[1]
+
+
+##############################################################################
+
+def test_get_source_info_wrong():
+    '''
+    Tests that get_source_info throws an exception if passed the wrong type
+    of argument.
+    '''
+    with pytest.raises(ValueError):
+        source_info = get_source_info(42)  # Obviously wrong
+
+    with pytest.raises(ValueError):
+        source_info = get_source_info(['one'])  # Less obviously wrong
 
 ##############################################################################

--- a/src/fparser/tests/test_sourceinfo.py
+++ b/src/fparser/tests/test_sourceinfo.py
@@ -107,7 +107,8 @@ def test_fortranformat_invalid():
     '''
     unit_under_test = FortranFormat(True, False)
     with pytest.raises(Exception):
-        unit_under_test == 'oranges'
+        if unit_under_test == 'oranges':
+            raise Exception("That shouldn't have happened")
 
 
 ##############################################################################

--- a/src/fparser/tests/test_sourceinfo.py
+++ b/src/fparser/tests/test_sourceinfo.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# Copyright (c) 2017-2018 Science and Technology Facilities Council
+#
+# All rights reserved.
+#
+# Modifications made as part of the fparser project are distributed
+# under the following license:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+##############################################################################
+# Modified M.Hambley, UK Met Office
+##############################################################################
+'''
+Test battery associated with fparser.sourceinfo package.
+'''
+from __future__ import print_function
+
+import pytest
+import fparser.sourceinfo
+
+@pytest.fixture(scope="module",
+                params=[('', True, True),
+                        ("-*- fortran -*-", False, True),
+                        ("-*- f77 -*-",     False, True),
+                        ('-*- f90 -*-',     True,  False),
+                        ('-*- f03 -*-',     True,  False),
+                        ('-*- f08 -*-',     True,  False),
+                        ('-*- fix -*-',     False, False),
+                        ('-*- pyf -*-',     True,  True)])
+def header(request):
+    return request.param
+
+_fixed_source = '''      program main
+      end program main
+'''
+
+_free_source = '''program main
+end program main
+'''
+
+_fixed_with_continuation = '''      program main
+          implicit none
+          integer :: foo, &
+                     bar
+      end program main
+'''
+
+_fixed_with_comments = '''!     The program
+      program main
+c         Enforce explicit variable declaration
+          implicit none
+*         variables
+          integer :: foo
+      end program main
+'''
+
+# Tabs are not actually in the Fortran character set but fparser has handled
+# them in the past even if it shouldn't have. We have to continue handling
+# them for the time being until we work out why they were supported.
+#
+_initial_tab = "\tprogram main\n"
+_middle_tab = " \tprogram main\n"
+
+@pytest.fixture(scope="module",
+                params=[(_fixed_source,            False, False),
+                        (_free_source,             True,  False),
+                        (_fixed_with_continuation, True,  False),
+                        (_fixed_with_comments,     False, False),
+                        (_initial_tab,             False, False),
+                        (_middle_tab,              True,  False)])
+def content(request):
+    return request.param
+
+def test_get_source_info_str(header, content):
+    full_source = header[0] + '\n' + content[0]
+    fixed, strict = fparser.sourceinfo.get_source_info_str(full_source)
+    if header[0]:
+      assert fixed  == header[1]
+      assert strict == header[2]
+    else: # No header
+      assert fixed  == content[1]
+      assert strict == content[2]

--- a/src/fparser/tests/test_sourceinfo.py
+++ b/src/fparser/tests/test_sourceinfo.py
@@ -42,7 +42,10 @@ Test battery associated with fparser.sourceinfo package.
 from __future__ import print_function
 
 import pytest
-from fparser.sourceinfo import FortranFormat, get_source_info_str
+import tempfile
+
+from fparser.sourceinfo import FortranFormat, \
+                               get_source_info_str, get_source_info
 
 @pytest.fixture(scope="module",
                 params=[('', FortranFormat(True, True)),
@@ -105,3 +108,21 @@ def test_get_source_info_str(header, content):
       assert format == header[1]
     else: # No header
       assert format == content[1]
+
+@pytest.fixture(scope="module",
+                params=[('.f', FortranFormat(False, True))])
+def extension(request):
+    return request.param
+
+def test_get_source_info_filename(extension, header, content):
+    full_source = header[0] + '\n' + content[0]
+    with tempfile.NamedTemporaryFile(mode='w+', suffix=extension[0]) as source_file:
+        print(full_source, file=source_file)
+        source_file.seek(0)
+        format = get_source_info(source_file.name)
+        if extension[0] == '.pyf':
+            assert format == extension[1]
+        elif header[0]:
+            assert format == header[1]
+        else: # No header
+            assert format == content[1]


### PR DESCRIPTION
This change is a precursor to allowing `FortranFileReader` to accept a file object as well as a filename.

Now the "source info" functions called by that class can accept a file object.

In order to try and ensure I did not change functionality I also added a suite of unit tests. I also took the opportunity to reduce code duplication.

I have tried this new version of fparser against the head of the PSyclone trunk and have two failures although it's not obvious that they were caused by this change. I seem to get the same two failures when running with the head of fparser trunk.