### PR TITLE
Fortran file reader now takes a file-like object as well as a filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Modifications by (in alphabetical order):
 * A. R. Porter, Science & Technology Facilities Council, UK
 * P. Vitt, University of Siegen, Germany
 
+23/03/2018 PR #75. Allow FortranFileReader to accept either a filename
+           or a file handle. Many pylint/pep8 improvements.
+
 05/03/2018 PR #73. Improvements to SourceInfo so that it can take either
 	   a filename or a file handle.
 

--- a/src/fparser/Fortran2003.py
+++ b/src/fparser/Fortran2003.py
@@ -334,7 +334,7 @@ content : tuple
                     end_name = obj.get_end_name()
                     if end_name != start_name:
                         reader.warning('expected construct name "%s" but got "%s"' % (start_name, end_name))
-                    
+
                 if endcls is not None and isinstance(obj, endcls_all):
                     if match_labels:
                         start_label, end_label = content[0].get_start_label(), content[-1].get_end_label()

--- a/src/fparser/api.py
+++ b/src/fparser/api.py
@@ -116,6 +116,8 @@ def get_reader(input, isfree=None, isstrict=None, include_dirs=None,
     import os
     import re
     from .readfortran import FortranFileReader, FortranStringReader
+    from fparser.sourceinfo import FortranFormat
+
     if os.path.isfile(input):
         name, ext = os.path.splitext(input)
         if ext.lower() in ['.c']:
@@ -143,10 +145,10 @@ def get_reader(input, isfree=None, isstrict=None, include_dirs=None,
         raise TypeError('Expected string or filename input but got %s' %
                         (type(input)))
     if isfree is None:
-        isfree = reader.isfree
+        isfree = reader.format.is_free
     if isstrict is None:
-        isstrict = reader.isstrict
-    reader.set_mode(isfree, isstrict)
+        isstrict = reader.format.is_strict
+    reader.set_format(FortranFormat(isfree, isstrict))
     return reader
 
 
@@ -224,6 +226,7 @@ def parse(input, isfree=None, isstrict=None, include_dirs=None,
     get_reader
     """
     from .parsefortran import FortranParser
+
     reader = get_reader(input, isfree, isstrict, include_dirs, source_only)
     parser = FortranParser(reader, ignore_comments=ignore_comments)
     try:

--- a/src/fparser/base_classes.py
+++ b/src/fparser/base_classes.py
@@ -544,7 +544,7 @@ class Statement(object, with_metaclass(classes)):
         return '\n'.join(l)
 
     def get_indent_tab(self,deindent=False,isfix=None):
-        if isfix is None: isfix = self.reader.isfixed
+        if isfix is None: isfix = self.reader.format.is_fixed
         if isfix:
             tab = ' '*6
         else:
@@ -710,7 +710,7 @@ class BeginStatement(Statement):
         Fills blocks content until the end of block statement.
         """
 
-        mode = self.reader.mode
+        mode = self.reader.format.mode
         class_list = self.get_classes()
         self.classes = [cls for cls in class_list if mode in cls.modes]
         self.pyf_classes = [cls for cls in class_list if 'pyf' in cls.modes]
@@ -766,7 +766,7 @@ class BeginStatement(Statement):
 
         # Check if f77 code contains inline comments or other f90
         # constructs that got undetected by get_source_info.
-        if item.reader.isf77:
+        if item.reader.format.is_f77:
             i = line.find('!')
             if i != -1:
                 message = item.reader.format_message(\

--- a/src/fparser/base_classes.py
+++ b/src/fparser/base_classes.py
@@ -224,7 +224,7 @@ class Variable(object, with_metaclass(classes)):
             if not self.typedecl == typedecl:
                 self.parent.warning(
                     'variable %r already has type %s, '
-                    ' resetting to %s'
+                    'resetting to %s'
                     % (self.name, self.typedecl.tostr(), typedecl.tostr()))
         assert typedecl is not None
         self.typedecl = typedecl
@@ -235,7 +235,7 @@ class Variable(object, with_metaclass(classes)):
             if not self.init == expr:
                 self.parent.warning(
                     'variable %r already has initialization %r, '
-                    ' resetting to %r' % (self.name, self.expr, expr))
+                    'resetting to %r' % (self.name, self.expr, expr))
         self.init = expr
         return
 
@@ -246,7 +246,7 @@ class Variable(object, with_metaclass(classes)):
             if not self.dimension == dims:
                 self.parent.warning(
                     'variable %r already has dimension %r, '
-                    ' resetting to %r' % (self.name, self.dimension, dims))
+                    'resetting to %r' % (self.name, self.dimension, dims))
         self.dimension = dims
         return
 
@@ -255,7 +255,7 @@ class Variable(object, with_metaclass(classes)):
             if not self.bounds == bounds:
                 self.parent.warning(
                     'variable %r already has bounds %r, '
-                    ' resetting to %r' % (self.name, self.bounds, bounds))
+                    'resetting to %r' % (self.name, self.bounds, bounds))
         self.bounds = bounds
         return
 
@@ -264,7 +264,7 @@ class Variable(object, with_metaclass(classes)):
             if not self.length == length:
                 self.parent.warning(
                     'variable %r already has length %r, '
-                    ' resetting to %r' % (self.name, self.length, length))
+                    'resetting to %r' % (self.name, self.length, length))
         self.length = length
         return
 
@@ -289,6 +289,12 @@ class Variable(object, with_metaclass(classes)):
                         'VOLATILE', 'REQUIRED']
 
     def is_intent_in(self):
+        # TODO Something hinky is going on here. self.intent is a list which
+        #      doesn't make a lot of sense. How can a variable have more
+        #      than one intent?
+        # TODO Furthermore if no intent is specified the assumed intent is
+        #      "inout". Below an explicit "inout" returns False but a None
+        #      returns True.
         if not self.intent:
             return True
         if 'HIDE' in self.intent:

--- a/src/fparser/block_statements.py
+++ b/src/fparser/block_statements.py
@@ -268,7 +268,7 @@ class BeginSource(BeginStatement):
         else:
             tab = self.get_indent_tab(isfix=isfix) + '!'
         return tab + BeginStatement.tofortran(self, isfix=isfix)
-        
+
     def tostr(self):
         return self.blocktype.upper() + ' '+ self.name
 
@@ -294,7 +294,7 @@ class BeginSource(BeginStatement):
         return
 
     def get_classes(self):
-        if self.reader.ispyf:
+        if self.reader.format.is_pyf:
             return [PythonModule] + program_unit
         return program_unit
 
@@ -303,7 +303,7 @@ class BeginSource(BeginStatement):
         # so it should never end until all lines are read.
         # However, sometimes F77 programs lack the PROGRAM statement,
         # and here we fix that:
-        if self.reader.isf77:
+        if self.reader.format.is_f77:
             line = item.get_line()
             if line=='end':
                 message = item.reader.format_message(\
@@ -528,7 +528,7 @@ class Interface(BeginStatement, HasAttributes, HasImplicitStmt, HasUseStmt,
 
     def get_classes(self):
         l = intrinsic_type_spec + interface_specification
-        if self.reader.mode=='pyf':
+        if self.reader.format.mode=='pyf':
             return [Subroutine, Function] + l
         return l
 
@@ -1000,7 +1000,7 @@ class If(BeginStatement):
 
     def process_item(self):
         item = self.item
-        mode = self.reader.mode
+        mode = self.reader.format.mode
         classes = self.get_classes()
         classes = [cls for cls in classes if mode in cls.modes]
 

--- a/src/fparser/parsefortran.py
+++ b/src/fparser/parsefortran.py
@@ -94,7 +94,7 @@ class FortranParser(object):
             parser = self.cache[reader.id]
             self.block = parser.block
             self.is_analyzed = parser.is_analyzed
-            logging.getLogger(__name__).info('using cached %s', (reader.id))
+            logging.getLogger(__name__).info('using cached %s' % (reader.id))
         else:
             self.cache[reader.id] = self
             self.block = None

--- a/src/fparser/parsefortran.py
+++ b/src/fparser/parsefortran.py
@@ -75,7 +75,6 @@ __all__ = ['FortranParser']
 import traceback
 import logging
 
-from .readfortran import FortranFileReader, FortranStringReader
 from .block_statements import BeginSource
 from .utils import AnalyzeError
 
@@ -95,7 +94,7 @@ class FortranParser(object):
             parser = self.cache[reader.id]
             self.block = parser.block
             self.is_analyzed = parser.is_analyzed
-            logging.getLogger(__name__).info('using cached %s' % (reader.id))
+            logging.getLogger(__name__).info('using cached %s', (reader.id))
         else:
             self.cache[reader.id] = self
             self.block = None
@@ -104,6 +103,9 @@ class FortranParser(object):
         return
 
     def get_item(self):
+        '''
+        Retrieves the next item from the reader.
+        '''
         try:
             item = self.reader.next(ignore_comments=self.ignore_comments)
             return item
@@ -112,6 +114,9 @@ class FortranParser(object):
         return
 
     def put_item(self, item):
+        '''
+        Pushes the given item to the reader.
+        '''
         self.reader.fifo_item.insert(0, item)
         return
 
@@ -139,6 +144,9 @@ class FortranParser(object):
         return
 
     def analyze(self):
+        '''
+        Attempts to analyse the parsed Fortran. It is not clear what for.
+        '''
         if self.is_analyzed:
             return
         if self.block is None:

--- a/src/fparser/parsefortran.py
+++ b/src/fparser/parsefortran.py
@@ -94,7 +94,7 @@ class FortranParser(object):
             parser = self.cache[reader.id]
             self.block = parser.block
             self.is_analyzed = parser.is_analyzed
-            logging.getLogger(__name__).info('using cached %s' % (reader.id))
+            logging.getLogger(__name__).info('using cached %s', (reader.id))
         else:
             self.cache[reader.id] = self
             self.block = None

--- a/src/fparser/readfortran.py
+++ b/src/fparser/readfortran.py
@@ -1364,7 +1364,7 @@ class FortranFileReader(FortranReaderBase):
             self.file = open(file_candidate, 'r')
             self._close_on_destruction = True
         elif hasattr(file_candidate,
-                     'next') and hasattr(file_candidate,
+                     'read') and hasattr(file_candidate,
                                          'name'):  # Is likely a file
             self.id = file_candidate.name
             self.file = file_candidate

--- a/src/fparser/readfortran.py
+++ b/src/fparser/readfortran.py
@@ -396,6 +396,7 @@ class Comment(object):
     def isempty(self, ignore_comments=False):
         return ignore_comments
 
+
 class MultiLine(object):
     """ Holds PYF file multiline.
 

--- a/src/fparser/readfortran.py
+++ b/src/fparser/readfortran.py
@@ -394,15 +394,7 @@ class Comment(object):
                % (self.comment, self.span)
 
     def isempty(self, ignore_comments=False):
-        '''
-        Returns true if there is no comment. This is always the case when
-        ignoring comments.
-        '''
-        if ignore_comments:
-            return True
-        else:
-            return self.comment.strip() == ''
-
+        return ignore_comments
 
 class MultiLine(object):
     """ Holds PYF file multiline.
@@ -477,7 +469,7 @@ class FortranReaderBase(object):
         ----------
         source :
           A file-like object with .next() method used to retrive a line.
-        format :
+        mode :
           A FortranFormat object as returned by sourceinfo.get_source_info()
 
         See also
@@ -546,7 +538,8 @@ class FortranReaderBase(object):
     @property
     def format(self):
         '''
-        Returns the currently applicable format.
+        :returns: the currently applicable format.
+        :rtype: :py:class:`fparser.sourceinfo.FortranFormat`
         '''
         return self._format
 
@@ -555,7 +548,8 @@ class FortranReaderBase(object):
     @property
     def name(self):
         '''
-        Returns a name for this reader.
+        :returns: the name of this reader.
+        :rtype: str
         '''
         return '{source} mode={mode}'.format(source=self.source,
                                              mode=self._format.mode)
@@ -1358,6 +1352,13 @@ class FortranFileReader(FortranReaderBase):
     Reads a file for Fortran source.
     '''
     def __init__(self, file_candidate, include_dirs=None, source_only=None):
+        '''
+        Constructs a FortranFileReader object from a file.
+        :param file_candidate: A filename or file-like object.
+        :param list include_dirs: Directories in which to look for inclusions.
+        :param list source_only: Fortran source files to search for modules
+                                 required by "use" statements.
+        '''
         mode = fparser.sourceinfo.get_source_info(file_candidate)
         if isinstance(file_candidate, six.string_types):
             self.id = file_candidate

--- a/src/fparser/readfortran.py
+++ b/src/fparser/readfortran.py
@@ -1360,7 +1360,6 @@ class FortranFileReader(FortranReaderBase):
         :param list source_only: Fortran source files to search for modules
                                  required by "use" statements.
         '''
-        mode = fparser.sourceinfo.get_source_info(file_candidate)
         if isinstance(file_candidate, six.string_types):
             self.id = file_candidate
             self.file = open(file_candidate, 'r')
@@ -1374,7 +1373,8 @@ class FortranFileReader(FortranReaderBase):
         else:  # Probably not something we can deal with
             message = 'FortranFileReader is used with a filename'
             message += ' or file-like object.'
-            raise Exception(message)
+            raise ValueError(message)
+        mode = fparser.sourceinfo.get_source_info(file_candidate)
 
         FortranReaderBase.__init__(self, self.file, mode)
 

--- a/src/fparser/scripts/f2003.py
+++ b/src/fparser/scripts/f2003.py
@@ -65,6 +65,7 @@
 
 import os
 import sys
+import fparser.sourceinfo
 ### START UPDATE SYS.PATH ###
 ### END UPDATE SYS.PATH ###
 try:
@@ -79,7 +80,8 @@ def runner (parser, options, args):
     for filename in args:
         reader = FortranFileReader(filename)
         if options.mode != 'auto':
-            reader.set_mode_from_str(options.mode)
+            mode = fparser.sourceinfo.FortranFormat.from_mode(options.mode)
+            reader.set_mode(mode)
         try:
             program = Fortran2003.Program(reader)
             print(program)

--- a/src/fparser/scripts/f2003.py
+++ b/src/fparser/scripts/f2003.py
@@ -63,8 +63,7 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
 
-import os
-import sys
+from fparser.script_options import set_f2003_options
 import fparser.sourceinfo
 ### START UPDATE SYS.PATH ###
 ### END UPDATE SYS.PATH ###
@@ -72,11 +71,11 @@ try:
     from iocbio.optparse_gui import OptionParser
 except ImportError:
     from optparse import OptionParser
-from fparser.script_options import set_f2003_options
 
-def runner (parser, options, args):
+
+def runner(parser, options, args):
     from fparser import Fortran2003
-    from fparser.readfortran import  FortranFileReader
+    from fparser.readfortran import FortranFileReader
     for filename in args:
         reader = FortranFileReader(filename)
         if options.mode != 'auto':
@@ -91,7 +90,8 @@ def runner (parser, options, args):
             print('quiting')
             return
 
-def main ():
+
+def main():
     parser = OptionParser()
     set_f2003_options(parser)
     if hasattr(parser, 'runner'):
@@ -100,5 +100,6 @@ def main ():
     runner(parser, options, args)
     return
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     main()

--- a/src/fparser/scripts/parse.py
+++ b/src/fparser/scripts/parse.py
@@ -65,6 +65,7 @@
 
 import os
 import sys
+import fparser.sourceinfo
 ### START UPDATE SYS.PATH ###
 ### END UPDATE SYS.PATH ###
 try:
@@ -79,7 +80,8 @@ def runner (parser, options, args):
     for filename in args:
         reader = FortranFileReader(filename)
         if options.mode != 'auto':
-            reader.set_mode_from_str(options.mode)
+            mode = fparser.sourceinfo.FortranFormat.from_mode(options.mode)
+            reader.set_mode(mode)
         parser = FortranParser(reader)
         parser.parse()
         parser.analyze()

--- a/src/fparser/scripts/parse.py
+++ b/src/fparser/scripts/parse.py
@@ -63,8 +63,7 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
 
-import os
-import sys
+from fparser.script_options import set_parse_options
 import fparser.sourceinfo
 ### START UPDATE SYS.PATH ###
 ### END UPDATE SYS.PATH ###
@@ -72,11 +71,11 @@ try:
     from iocbio.optparse_gui import OptionParser
 except ImportError:
     from optparse import OptionParser
-from fparser.script_options import set_parse_options
 
-def runner (parser, options, args):
-    from fparser.readfortran import  FortranFileReader
-    from fparser.parsefortran import  FortranParser
+
+def runner(parser, options, args):
+    from fparser.readfortran import FortranFileReader
+    from fparser.parsefortran import FortranParser
     for filename in args:
         reader = FortranFileReader(filename)
         if options.mode != 'auto':
@@ -85,15 +84,15 @@ def runner (parser, options, args):
         parser = FortranParser(reader)
         parser.parse()
         parser.analyze()
-        if options.task=='show':
+        if options.task == 'show':
             print(parser.block.torepr(4))
         elif options.task == 'none':
             pass
         else:
             raise NotImplementedError(repr(options.task))
-        
 
-def main ():
+
+def main():
     parser = OptionParser()
     set_parse_options(parser)
     if hasattr(parser, 'runner'):
@@ -102,5 +101,6 @@ def main ():
     runner(parser, options, args)
     return
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     main()

--- a/src/fparser/sourceinfo.py
+++ b/src/fparser/sourceinfo.py
@@ -194,9 +194,9 @@ class FortranFormat(object):
             mode = 'fix'
         elif self.is_f77:
             mode = 'f77'
-        else:
-            message = 'FortranFormat stuck in bad mode: {} {}'
-            raise Exception(message.format(self.is_free, self.is_strict))
+        # While mode is determined by is_free and is_strict all permutations
+        # are covered. There is no need for a final "else" clause as the
+        # object cannot get wedged in an invalid mode.
         return mode
 
 

--- a/src/fparser/sourceinfo.py
+++ b/src/fparser/sourceinfo.py
@@ -92,22 +92,47 @@ class FortranFormat(object):
             is_free   - (Boolean) True for free format, False for fixed.
             is_strict - (Boolean) Some amount of strictness.
         '''
+        if is_free is None:
+            raise Exception('FortranFormat does not accept a None is_free')
+        if is_strict is None:
+            raise Exception('FortranFormat does not accept a None is_strict')
+
         self._is_free = is_free
         self._is_strict = is_strict
 
+    @classmethod
+    def from_mode(cls, mode):
+        '''
+        Constructs a FortranFormat object from a mode string.
+
+        Arguments:
+            mode - (String) One of 'free', 'fix', 'f77' or 'pyf'
+        '''
+        if mode=='free':
+            is_free, is_strict=True, False
+        elif mode=='fix':
+            is_free, is_strict=False, False
+        elif mode=='f77':
+            is_free, is_strict=False, True
+        elif mode=='pyf':
+            is_free, is_strict=True, True
+        else:
+            raise NotImplementedError(repr(mode))
+        return cls(is_free, is_strict)
+
     def __eq__(self, other):
         if isinstance(other, FortranFormat):
-            return self._is_free == other.is_free \
-                   and self._is_strict == other.is_strict
+            return self.is_free == other.is_free \
+                   and self.is_strict == other.is_strict
         raise NotImplementedError
 
     def __str__(self):
-        if self._is_strict:
+        if self.is_strict:
             string = 'Strict'
         else:
             string = 'Non-strict'
 
-        if self._is_free:
+        if self.is_free:
             string += ' free'
         else:
             string += ' fixed'
@@ -117,16 +142,62 @@ class FortranFormat(object):
     @property
     def is_free(self):
         '''
-        Returns true if the "free format" flag is set.
+        Returns true for free format.
         '''
         return self._is_free
 
     @property
+    def is_fixed(self):
+        '''
+        Returns true for fixed format.
+        '''
+        return not self._is_free
+
+    @property
     def is_strict(self):
         '''
-        Returns true if the "strict" flag is set.
+        Returns true for strict format.
         '''
         return self._is_strict
+
+    @property
+    def is_f77(self):
+        '''
+        Returns true for strict fixed format.
+        '''
+        return not self._is_free and self._is_strict
+
+    @property
+    def is_fix(self):
+        '''
+        Returns true for slack fixed format.
+        '''
+        return not self._is_free and not self._is_strict
+
+    @property
+    def is_pyf(self):
+        '''
+        Returns true for strict free format.
+        '''
+        return self._is_free and self._is_strict
+
+    @property
+    def mode(self):
+        '''
+        Returns a string representing this format.
+        '''
+        if self._is_free and self._is_strict:
+            mode = 'pyf'
+        elif self._is_free:
+            mode = 'free'
+        elif self.is_fix:
+            mode = 'fix'
+        elif self.is_f77:
+            mode = 'f77'
+        else:
+            message = 'FortranFormat stuck in bad mode: {} {}'
+            raise Exception(message.format(self.is_free, self.is_strict))
+        return mode
 
 
 ##############################################################################

--- a/src/fparser/sourceinfo.py
+++ b/src/fparser/sourceinfo.py
@@ -276,7 +276,7 @@ def get_source_info(file_candidate):
         # and Python3.
         filename = file_candidate
     else:
-        message = 'Argument must be a file or filename.'
+        message = 'Argument must be a filename or file-like object.'
         raise ValueError(message)
 
     if filename:

--- a/src/fparser/sourceinfo.py
+++ b/src/fparser/sourceinfo.py
@@ -108,14 +108,14 @@ class FortranFormat(object):
         Arguments:
             mode - (String) One of 'free', 'fix', 'f77' or 'pyf'
         '''
-        if mode=='free':
-            is_free, is_strict=True, False
-        elif mode=='fix':
-            is_free, is_strict=False, False
-        elif mode=='f77':
-            is_free, is_strict=False, True
-        elif mode=='pyf':
-            is_free, is_strict=True, True
+        if mode == 'free':
+            is_free, is_strict = True, False
+        elif mode == 'fix':
+            is_free, is_strict = False, False
+        elif mode == 'f77':
+            is_free, is_strict = False, True
+        elif mode == 'pyf':
+            is_free, is_strict = True, True
         else:
             raise NotImplementedError(repr(mode))
         return cls(is_free, is_strict)

--- a/src/fparser/tests/test_base_classes.py
+++ b/src/fparser/tests/test_base_classes.py
@@ -44,6 +44,7 @@ import pytest
 import fparser.base_classes
 import fparser.parsefortran
 import fparser.readfortran
+import fparser.sourceinfo
 import fparser.utils
 
 
@@ -108,7 +109,7 @@ def test_log_comment_mix(log):
 
     code = '      x=1 ! Cheese'
     parent = fparser.readfortran.FortranStringReader(code)
-    parent.set_mode(False, True)
+    parent.set_format(fparser.sourceinfo.FortranFormat(False, True))
     item = fparser.readfortran.Line(code, (1, 1), None, None, parent)
     with pytest.raises(fparser.utils.AnalyzeError):
         __ = BeginHarness(parent, item)
@@ -148,7 +149,7 @@ def test_log_unexpected(log):
 
     code = ['      jumper', '      end thing']
     parent = fparser.readfortran.FortranStringReader('\n'.join(code))
-    parent.set_mode(False, True)
+    parent.set_format(fparser.sourceinfo.FortranFormat(False, True))
     item = fparser.readfortran.Line(code[0], (1, 1), None, None, parent)
     with pytest.raises(fparser.utils.AnalyzeError):
         __ = BeginThing(parent, item)

--- a/src/fparser/tests/test_parsefortran.py
+++ b/src/fparser/tests/test_parsefortran.py
@@ -146,7 +146,7 @@ end python module foo
                 '  END PYTHONMODULE foo']
 
     reader = fparser.readfortran.FortranStringReader(string)
-    reader.set_mode_from_str('pyf')
+    reader.set_format(fparser.sourceinfo.FortranFormat.from_mode('pyf'))
     parser = fparser.parsefortran.FortranParser(reader)
     parser.parse()
     caught = parser.block.tofortran().splitlines()
@@ -204,7 +204,7 @@ end module foo
                 '  END MODULE foo']
 
     reader = fparser.readfortran.FortranStringReader(string)
-    reader.set_mode_from_str('free')
+    reader.set_format(fparser.sourceinfo.FortranFormat.from_mode('free'))
     parser = fparser.parsefortran.FortranParser(reader)
     parser.parse()
     caught = parser.block.tofortran().splitlines()

--- a/src/fparser/tests/test_parser.py
+++ b/src/fparser/tests/test_parser.py
@@ -82,7 +82,7 @@ from fparser.block_statements import Allocatable, Allocate, ArithmeticIf, \
      Pointer, PointerAssignment, Pause, Print, Private, Protected, Public, \
      Read, Return, Rewind, Save, Sequence, SpecificBinding, Stop, Target, \
      Threadsafe, Use, Value, Volatile, Wait, WhereStmt, Write
-
+import fparser.sourceinfo
 from fparser.typedecl_statements import Byte, Character, Complex, \
      DoubleComplex, DoublePrecision, Integer, Logical, Real
 
@@ -103,7 +103,7 @@ def parse(cls, line, label='', isfree=True, isstrict=False):
     if label:
         line = label + ' : ' + line
     reader = FortranStringReader(line)
-    reader.set_mode(isfree, isstrict)
+    reader.set_format(fparser.sourceinfo.FortranFormat(isfree, isstrict))
     item = next(reader)
     if not cls.match(item.get_line()):
         raise ValueError('%r does not match %s pattern' % (line, cls.__name__))

--- a/src/fparser/tests/test_readfortran.py
+++ b/src/fparser/tests/test_readfortran.py
@@ -403,8 +403,10 @@ def test_bad_file_reader():
     Tests that the file reader can spot when it is given something to read
     which is neither file nor filename.
     '''
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError) as ex:
         unit_under_test = FortranFileReader(42)
+    expected = 'FortranFileReader is used with a filename or file-like object.'
+    assert expected in str(ex)
 
 
 ##############################################################################

--- a/src/fparser/tests/test_readfortran.py
+++ b/src/fparser/tests/test_readfortran.py
@@ -351,6 +351,9 @@ FULL_FREE_EXPECTED = ['program test',
 ##############################################################################
 
 def test_filename_reader():
+    '''
+    Tests that a Fortran source file can be read given its filename.
+    '''
     handle, filename = tempfile.mkstemp(suffix='.f90', text=True)
     os.close(handle)
     try:
@@ -371,6 +374,9 @@ def test_filename_reader():
 ##############################################################################
 
 def test_file_reader():
+    '''
+    Tests that a Fortran source file can be read given a file object of it.
+    '''
     handle, filename = tempfile.mkstemp(suffix='.f90', text=True)
     os.close(handle)
     try:
@@ -389,6 +395,16 @@ def test_file_reader():
         os.unlink(filename)
         raise
 
+
+##############################################################################
+
+def test_bad_file_reader():
+    '''
+    Tests that the file reader can spot when it is given something to read
+    which is neither file nor filename.
+    '''
+    with pytest.raises(Exception):
+        unit_under_test = FortranFileReader( 42 )
 
 ##############################################################################
 

--- a/src/fparser/tests/test_readfortran.py
+++ b/src/fparser/tests/test_readfortran.py
@@ -404,11 +404,15 @@ def test_bad_file_reader():
     which is neither file nor filename.
     '''
     with pytest.raises(Exception):
-        unit_under_test = FortranFileReader( 42 )
+        unit_under_test = FortranFileReader(42)
+
 
 ##############################################################################
 
 def test_string_reader():
+    '''
+    Tests that Fortran source can be read from a string.
+    '''
     unit_under_test = FortranStringReader(FULL_FREE_SOURCE)
     expected = fparser.sourceinfo.FortranFormat(True, False)
     assert unit_under_test.format == expected

--- a/src/fparser/tests/test_select.py
+++ b/src/fparser/tests/test_select.py
@@ -68,6 +68,7 @@ Test fparser support for parsing select-case and select-type blocks
 """
 
 import pytest
+import fparser.sourceinfo
 
 
 # We need to monkeypatch the logger used by fparser because it grabs
@@ -105,7 +106,7 @@ def test_case_internal_error(monkeypatch, capsys):
     from fparser.block_statements import Case
     from fparser.readfortran import FortranStringReader
     reader = FortranStringReader('CASE (yes)')
-    reader.set_mode(True, False)
+    reader.set_format(fparser.sourceinfo.FortranFormat(True, False))
     item = next(reader)
     stmt = Case(item, item)
     # Monkeypatch our valid Case object so that get_line() now
@@ -130,7 +131,7 @@ def test_class_internal_error(monkeypatch, capsys):
     from fparser.block_statements import ClassIs
     from fparser.readfortran import FortranStringReader
     reader = FortranStringReader('CLASS IS (yes)')
-    reader.set_mode(True, False)
+    reader.set_format(fparser.sourceinfo.FortranFormat(True, False))
     item = next(reader)
     stmt = ClassIs(item, item)
     # Monkeypatch our valid Case object so that get_line() now

--- a/src/fparser/tests/test_select.py
+++ b/src/fparser/tests/test_select.py
@@ -152,7 +152,6 @@ def test_class_internal_error(monkeypatch, capsys):
 def test_select_case():
     '''Test that fparser correctly recognises select case'''
     from fparser import api
-    import fparser
     source_str = '''
     subroutine foo
     integer :: iflag = 1
@@ -193,7 +192,6 @@ def test_select_case():
 def test_named_select_case():
     '''Test that fparser correctly recognises a named select case'''
     from fparser import api
-    import fparser
     source_str = '''
     subroutine foo
     integer :: iflag = 1
@@ -227,7 +225,6 @@ def test_select_case_brackets():
     '''Test that fparser correctly parses a select case involving
     parentheses '''
     from fparser import api
-    import fparser
     source_str = '''
     subroutine foo
     integer :: iflag(2) = 1
@@ -258,7 +255,6 @@ def test_select_case_brackets():
 def test_select_type():
     '''Test that fparser correctly recognises select type'''
     from fparser import api
-    import fparser
     source_str = '''
     subroutine foo(an_object)
     class(*) :: an_object
@@ -308,7 +304,6 @@ def test_select_type():
 def test_type_is_process_item(monkeypatch, capsys):
     ''' Test error condition raised in TypeIs.process_item() method '''
     from fparser import api
-    import fparser
     source_str = '''
     subroutine foo(an_object)
     class(*) :: an_object
@@ -346,7 +341,6 @@ def test_type_is_process_item(monkeypatch, capsys):
 def test_type_is_to_fortran():
     ''' Test error condition raised in TypeIs.to_fortran() method '''
     from fparser import api
-    import fparser
     from fparser.utils import ParseError
     source_str = '''
     subroutine foo(an_object)
@@ -382,7 +376,6 @@ def test_type_is_to_fortran():
 def test_class_is_process_item(monkeypatch, capsys):
     ''' Test error condition raised in ClassIs.process_item() method '''
     from fparser import api
-    import fparser
     source_str = '''
     subroutine foo(an_object)
     class(*) :: an_object
@@ -420,7 +413,6 @@ def test_class_is_process_item(monkeypatch, capsys):
 def test_class_is_to_fortran():
     ''' Test ClassIs.to_fortran() method '''
     from fparser import api
-    import fparser
     source_str = '''
     subroutine foo(an_object)
     class(*) :: an_object

--- a/src/fparser/tests/test_sourceinfo.py
+++ b/src/fparser/tests/test_sourceinfo.py
@@ -50,6 +50,20 @@ from fparser.sourceinfo import FortranFormat, \
 
 
 ##############################################################################
+
+def test_fortranformat_constructor():
+    '''
+    Tests that the constructor correctly rejects attempts to create an object
+    with "None" arguments.
+    '''
+    with pytest.raises(Exception):
+        unit_under_test = FortranFormat(True, None)
+
+    with pytest.raises(Exception):
+        unit_under_test = FortranFormat(None, True)
+
+
+##############################################################################
 @pytest.fixture(scope="module",
                 params=[(False, False, 'Non-strict fixed format'),
                         (False, True, 'Strict fixed format'),

--- a/src/fparser/tests/test_sourceinfo.py
+++ b/src/fparser/tests/test_sourceinfo.py
@@ -165,6 +165,16 @@ def test_fortranformat_from_mode(mode):
 
 
 ##############################################################################
+
+def test_fortranformat_from_mode_bad():
+    '''
+    Tests that an exception is thrown for an unrecognised mode string.
+    '''
+    with pytest.raises(NotImplementedError):
+        unit_under_test = FortranFormat.from_mode('cheese')
+
+
+##############################################################################
 # Setting up a pytest fixture in this way is a mechanism for creating
 # parameterised tests.
 #

--- a/src/fparser/tests/test_sourceinfo.py
+++ b/src/fparser/tests/test_sourceinfo.py
@@ -51,7 +51,7 @@ from fparser.sourceinfo import FortranFormat, \
 
 ##############################################################################
 
-def test_fortranformat_constructor():
+def test_fortranformat_constructor_faults():
     '''
     Tests that the constructor correctly rejects attempts to create an object
     with "None" arguments.
@@ -65,25 +65,33 @@ def test_fortranformat_constructor():
 
 ##############################################################################
 @pytest.fixture(scope="module",
-                params=[(False, False, 'Non-strict fixed format'),
-                        (False, True, 'Strict fixed format'),
-                        (True, False, 'Non-strict free format'),
-                        (True, True, 'Strict free format')])
+                params=[(False, False, 'fix', 'Non-strict fixed format'),
+                        (False, True, 'f77', 'Strict fixed format'),
+                        (True, False, 'free', 'Non-strict free format'),
+                        (True, True, 'pyf', 'Strict free format')])
 def pretty(request):
     '''
-    Returns parameters for format tests.
+    Returns all possible permutations of flags and their corresponding
+    mode and descriptive strings.
     '''
     return request.param
 
 
 ##############################################################################
 
-def test_fortranformat_string(pretty):
+def test_fortranformat_constructor(pretty):
     '''
-    Tests for the correct string representations.
+    Tests the constructor correctly sets up the object.
     '''
     unit_under_test = FortranFormat(pretty[0], pretty[1])
-    assert str(unit_under_test) == pretty[2]
+    assert str(unit_under_test) == pretty[3]
+    assert unit_under_test.is_free == pretty[0]
+    assert unit_under_test.is_fixed == (not pretty[0])
+    assert unit_under_test.is_strict == pretty[1]
+    assert unit_under_test.is_f77 == (not pretty[0] and pretty[1])
+    assert unit_under_test.is_fix == (not pretty[0] and not pretty[1])
+    assert unit_under_test.is_pyf == (pretty[0] and pretty[1])
+    assert unit_under_test.mode == pretty[2]
 
 
 ##############################################################################
@@ -123,6 +131,37 @@ def test_fortranformat_invalid():
     with pytest.raises(NotImplementedError):
         if unit_under_test == 'oranges':
             raise Exception("That shouldn't have happened")
+
+
+##############################################################################
+
+@pytest.fixture(scope="module",
+                params=[('free', True, False),
+                        ('f77', False, True),
+                        ('fix', False, False),
+                        ('pyf', True, True)])
+def mode(request):
+    '''
+    Returns all possible mode strings and their corresponding flags.
+    '''
+    return request.param
+
+
+##############################################################################
+
+def test_fortranformat_from_mode(mode):
+    '''
+    Tests that the object is correctly created by the from_mode function.
+    '''
+    unit_under_test = FortranFormat.from_mode(mode[0])
+    assert unit_under_test.mode == mode[0]
+    assert unit_under_test.is_free == mode[1]
+    assert unit_under_test.is_fixed == (not mode[1])
+    assert unit_under_test.is_strict == mode[2]
+    assert unit_under_test.is_f77 == (not mode[1] and mode[2])
+    assert unit_under_test.is_fix == (not mode[1] and not mode[2])
+    assert unit_under_test.is_pyf == (mode[1] and mode[2])
+    assert str(unit_under_test.mode) == mode[0]
 
 
 ##############################################################################


### PR DESCRIPTION
This change allows the Fortran reader to operate on an already open file-like object as well as on a filename which it opens itself. This is to ease life for users of the fparser library.

I have also spread the use of the FortranFormat object created in my previous branch into the file reader. This just encapsulates a lot of knowledge about Fortran source formats. It also corrals some of the less well understood aspects of the library. Such as what "fix" and "pyf" are.

Given that I always get hit up for this anyway I've also run pycodestyle over a number of big files and dealt with the result. Note I haven't used pylint as that runs headlong into a lot of legacy issues. I hope that can be left for another day.
