### PR TITLE
names with spaces now raise an exception. #112

### DIFF
--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -566,6 +566,7 @@ class Name(StringBase):  # R304
         :param str string: the string to match with the pattern rule.
         :returns: a tuple of size 1 containing a string with the \
         matched name if there is a match, or None if there is not.
+        :rtype: (str) or None
 
         '''
         return StringBase.match(pattern.abs_name, string.strip())

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -550,14 +550,25 @@ class Keyword(Base):  # R215
 
 
 class Name(StringBase):  # R304
-    """
-    <name> = <letter> [ <alphanumeric_character> ]...
-    """
+    '''
+    Fortran 2003 rule R304
+    name is letter [ alphanumeric_character ]...
+
+    '''
+    # There are no other classes. This is a simple string match.
     subclass_names = []
 
     @staticmethod
     def match(string):
-        return StringBase.match(pattern.abs_name, string.replace(' ', ''))
+        '''Match the string with the regular expression abs_name in the
+        pattern_tools file.
+
+        :param str string: the string to match with the pattern rule.
+        :returns: a tuple of size 1 containing a string with the \
+        matched name if there is a match, or None if there is not.
+
+        '''
+        return StringBase.match(pattern.abs_name, string.strip())
 
 
 class Constant(Base):  # R305

--- a/src/fparser/two/tests/fortran2003/test_name_r304.py
+++ b/src/fparser/two/tests/fortran2003/test_name_r304.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2018 Science and Technology Facilities Council
+
+# All rights reserved.
+
+# Modifications made as part of the fparser project are distributed
+# under the following license:
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+'''Test Fortran 2003 rule R304 : This file tests support for the Name
+class.
+
+'''
+
+import pytest
+from fparser.two.utils import NoMatchError
+from fparser.two.Fortran2003 import Name
+
+# Test the name class R304
+
+
+def test_valid_names():
+    '''Test the appropriate set of valid names. Note, '$' is not valid in
+    the standard but is supported by some compilers so we allow it
+    here.
+
+    '''
+    for name in ["a", "abcde", "a_", "a1", "  a  ", "a$"]:
+        result = Name(name)
+        assert str(result) == name.strip()
+
+
+def test_invalid_names():
+    '''Test invalid names. There are too many to try all invalid
+    characters so just do a subset.
+
+    '''
+    for name in ["1", "_", "1a", "_a", "a a", "", " ", "a!", "a@", "a#",
+                 "a%", "a^", "a&", "a*", "a(", "a)"]:
+        with pytest.raises(NoMatchError) as excinfo:
+            _ = Name(name)
+        assert "Name: '{0}'".format(name) in str(excinfo.value)

--- a/src/fparser/two/tests/test_fortran2003.py
+++ b/src/fparser/two/tests/test_fortran2003.py
@@ -126,12 +126,6 @@ end type b
 #
 
 
-def test_name():  # R304
-
-    obj = Name('a')
-    assert isinstance(obj, Name), repr(obj)
-    obj = Name('a2')
-    assert isinstance(obj, Name), repr(obj)
     objd = Designator('a')
     assert isinstance(objd, Name), repr(objd)
     objc = Constant('a')

--- a/src/fparser/two/tests/test_fortran2003.py
+++ b/src/fparser/two/tests/test_fortran2003.py
@@ -126,14 +126,6 @@ end type b
 #
 
 
-    objd = Designator('a')
-    assert isinstance(objd, Name), repr(objd)
-    objc = Constant('a')
-    assert isinstance(objc, Name), repr(objc)
-    obje = Expr('a')
-    assert isinstance(obje, Name), repr(obje)
-
-
 def test_constant():
     ''' Tests that various types of constant expressions are parsed
     correctly (R305). The example here is for Literal_Constant


### PR DESCRIPTION
If we provide an name with internal spaces we now get an error. e.g.
```
program a a
end program
```
will now produce a syntax error.
