### PR TITLE
Derived type stmt error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Modifications by (in alphabetical order):
 * A. R. Porter, Science & Technology Facilities Council, UK
 * P. Vitt, University of Siegen, Germany
 
+28/11/2018 PR #133 for issue #130. Bug fix for handing of derived-type
+           statements.
+
 28/11/2018 PR #134 for issue #119. Bug fix for parsing files that contain
            nothing or just white space.
 

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -1183,6 +1183,8 @@ class Derived_Type_Stmt(StmtBase):  # pylint: disable=invalid-name
         '''
         :return: this derived type statement as a string
         :rtype: str
+        :raises InternalError: if items array is not the expected size
+        :raises InternalError: if items array[1] has no content
 
         '''
         if len(self.items) != 3:

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -1125,32 +1125,52 @@ class Derived_Type_Def(BlockBase):  # R429
 
 
 class Derived_Type_Stmt(StmtBase):  # R430
-    """<derived-type-stmt> = TYPE [ [ , <type-attr-spec-list> ] :: ]
-    <type-name> [ ( <type-param-name-list> ) ]
+    '''
+    derived-type-stmt is TYPE [ [ , type-attr-spec-list ] :: ]
+                         type-name [ ( type-param-name-list ) ]
 
-    """
+    '''
     subclass_names = []
     use_names = ['Type_Attr_Spec_List', 'Type_Name', 'Type_Param_Name_List']
 
     @staticmethod
     def match(string):
-        if string[:4].upper() != 'TYPE':
+        '''Implements the matching for a Derived Type Statement.
+
+        :param str string: a string containing the code to match
+
+        :return: `None` if there is no match, otherwise a `tuple` of
+                 size 3 containing the Attribute Spec List (or None if
+                 there isn't one), the name of the type and parameter
+                 name list (or None is there isn't one).
+        :rtype: ( `Type_Attr_Spec_List`, str, `Type_Param_Name_List`
+                or `None` ) or `None`
+
+        '''
+        string_strip = string.strip()
+        if string_strip[:4].upper() != 'TYPE':
             return
-        line = string[4:].lstrip()
-        i = line.find('::')
+        line = string_strip[4:].lstrip()
+        position = line.find('::')
         attr_specs = None
-        if i != -1:
+        if position != -1:
             if line.startswith(','):
-                lstrip = line[1:i].strip()
+                lstrip = line[position:position].strip()
                 if not lstrip:
+                    # There is no content after the "," and before the
+                    # "::"
                     return
                 attr_specs = Type_Attr_Spec_List(lstrip)
-            line = line[i+2:].lstrip()
-        m = pattern.name.match(line)
-        if m is None:
+            elif line[:position].strip():
+                # There is invalid content between and 'TYPE' and '::'
+                return
+            line = line[position+2:].lstrip()
+        match = pattern.name.match(line)
+        if not match:
+            # There is no content after the "TYPE" or the "::"
             return
-        name = Type_Name(m.group())
-        line = line[m.end():].lstrip()
+        name = Type_Name(match.group())
+        line = line[match.end():].lstrip()
         if not line:
             return attr_specs, name, None
         if line[0] + line[-1] != '()':
@@ -1158,16 +1178,26 @@ class Derived_Type_Stmt(StmtBase):  # R430
         return attr_specs, name, Type_Param_Name_List(line[1:-1].strip())
 
     def tostr(self):
-        s = 'TYPE'
-        if self.items[0] is not None:
-            s += ', %s :: %s' % (self.items[0], self.items[1])
+        '''
+        :return: this derived type statement as a string
+        :rtype: str
+
+        '''
+        string = 'TYPE'
+        if self.items[0]:
+            string += ", {0} :: {1}".format(self.items[0], self.items[1])
         else:
-            s += ' :: %s' % (self.items[1])
-        if self.items[2] is not None:
-            s += '(%s)' % (self.items[2])
-        return s
+            string += " :: {0}".format(self.items[1])
+        if self.items[2]:
+            string += "({0})".format(self.items[2])
+        return string
 
     def get_start_name(self):
+        '''
+        :return: this derived type statement's name as a string
+        :rtype: str
+
+        '''
         return self.items[1].string
 
 

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -1140,13 +1140,13 @@ class Derived_Type_Stmt(StmtBase):  # pylint: disable=invalid-name
         '''Implements the matching for a Derived Type Statement.
 
         :param str string: a string containing the code to match
-        :return: `None` if there is no match, otherwise a `tuple` of
-                 size 3 containing an `Attribute_Spec_List` (or `None` if
-                 there isn't one), the name of the type (in a `Name`
-                 class) and a `Parameter_Name_List` (or `None` is there
+        :return: `None` if there is no match, otherwise a `tuple` of \
+                 size 3 containing an `Attribute_Spec_List` (or `None` if \
+                 there isn't one), the name of the type (in a `Name` \
+                 class) and a `Parameter_Name_List` (or `None` is there \
                  isn't one).
-        :rtype: ( `Type_Attr_Spec_List` or `None`, `Name`, `Type_Param_Name_List`
-                or `None` ) or `None`
+        :rtype: ( `Type_Attr_Spec_List` or `None`, `Name`, \
+                  `Type_Param_Name_List` or `None` ) or `None`
 
         '''
         string_strip = string.strip()
@@ -1189,11 +1189,11 @@ class Derived_Type_Stmt(StmtBase):  # pylint: disable=invalid-name
         '''
         if len(self.items) != 3:
             raise InternalError(
-                "Derived_Type_Stmt.tostr(). 'Items' should be of size 3 but "
+                "Derived_Type_Stmt.tostr(). 'items' should be of size 3 but "
                 "found '{0}'.".format(len(self.items)))
         if not self.items[1]:
             raise InternalError(
-                "Derived_Type_Stmt.tostr(). 'Items[1]' should be a Name "
+                "Derived_Type_Stmt.tostr(). 'items[1]' should be a Name "
                 "instance containing the derived type name but it is empty")
         string = 'TYPE'
         if self.items[0]:

--- a/src/fparser/two/tests/fortran2003/test_derived_type_stmt_r430.py
+++ b/src/fparser/two/tests/fortran2003/test_derived_type_stmt_r430.py
@@ -110,8 +110,8 @@ def test_errors(f2003_create):
 
 
 def test_tostr_1(f2003_create, monkeypatch):
-    '''Check that a derived_type_stmt method tostr() exception is
-    raised if there are an invalid number of items
+    '''Check that Derived_Type_Stmt.tostr() raises an exception if there
+    is an invalid number of items.
 
     '''
 
@@ -123,8 +123,8 @@ def test_tostr_1(f2003_create, monkeypatch):
 
 
 def test_tostr_2(f2003_create, monkeypatch):
-    '''Check that a derived_type_stmt method tostr() exception is
-    raised.
+    '''Check that Derived_Type_Stmt.tostr() raises an exception if the
+    content of items[1] is invalid.
 
     '''
 
@@ -132,7 +132,7 @@ def test_tostr_2(f2003_create, monkeypatch):
     monkeypatch.setattr(ast, "items", [None, None, None])
     with pytest.raises(InternalError) as excinfo:
         str(ast)
-    assert ("'Items[1]' should be a Name instance containing the "
+    assert ("'items[1]' should be a Name instance containing the "
             "derived type name but it is empty") in str(excinfo)
 
 

--- a/src/fparser/two/tests/fortran2003/test_derived_type_stmt_r430.py
+++ b/src/fparser/two/tests/fortran2003/test_derived_type_stmt_r430.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2018 Science and Technology Facilities Council
+
+# All rights reserved.
+
+# Modifications made as part of the fparser project are distributed
+# under the following license:
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+'''Test Fortran 2003 rule R430 : This file tests the support for the
+Derived Type Statement e.g.
+
+type, private, abstract :: my_type(b,c)
+
+'''
+
+import pytest
+from fparser.two.Fortran2003 import Derived_Type_Stmt
+from fparser.two.utils import NoMatchError, InternalError
+
+
+def test_valid(f2003_create):
+    '''Check that valid input is parsed correctly.
+
+    '''
+
+    # simple minimal type statement
+    ast = Derived_Type_Stmt("type a")
+    assert "TYPE :: a" in str(ast)
+    assert repr(ast) == "Derived_Type_Stmt(None, Type_Name('a'), None)"
+
+    # simple minimal type statement with spaces
+    ast = Derived_Type_Stmt("  type  a  ")
+    assert "TYPE :: a" in str(ast)
+
+    # simple minimal type statement with no spaces
+    ast = Derived_Type_Stmt("typea")
+    assert "TYPE :: a" in str(ast)
+
+    # simple minimal type statement with "::"
+    ast = Derived_Type_Stmt("type :: a")
+    assert "TYPE :: a" in str(ast)
+
+    # type statement with attribute spec list
+    ast = Derived_Type_Stmt("type, private, abstract :: a")
+    assert "TYPE, PRIVATE, ABSTRACT :: a" in str(ast)
+    assert repr(ast) == ("Derived_Type_Stmt(Type_Attr_Spec_List(',', "
+                         "(Access_Spec('PRIVATE'), "
+                         "Type_Attr_Spec('ABSTRACT', None))), "
+                         "Type_Name('a'), None)")
+
+    # type statement with type parameter name list
+    ast = Derived_Type_Stmt("type, private, abstract :: a(b,c)")
+    assert "TYPE, PRIVATE, ABSTRACT :: a(b, c)" in str(ast)
+    assert repr(ast) == ("Derived_Type_Stmt(Type_Attr_Spec_List(',', "
+                         "(Access_Spec('PRIVATE'), "
+                         "Type_Attr_Spec('ABSTRACT', None))), "
+                         "Type_Name('a'), Type_Param_Name_List(',', "
+                         "(Name('b'), Name('c'))))")
+
+    # type statement with type parameter name list spaces
+    ast = Derived_Type_Stmt("  type , private , abstract :: a ( b , c )  ")
+    assert "TYPE, PRIVATE, ABSTRACT :: a(b, c)" in str(ast)
+
+    # type statement with type parameter name list no spaces
+    ast = Derived_Type_Stmt("type,private,abstract::a(b,c)")
+    assert "TYPE, PRIVATE, ABSTRACT :: a(b, c)" in str(ast)
+
+    # type statement with type parameter name list no colons
+    ast = Derived_Type_Stmt("type a(b,c)")
+    assert "TYPE :: a(b, c)" in str(ast)
+
+
+def test_errors(f2003_create):
+    '''Check that invalid input does not match.
+
+    '''
+
+    for value in ["", "  ", "typ", "type", "type ::", "type, ::",
+                  "type x ::", "type a b", "type a()", "type a(  )",
+                  "type a(b) c"]:
+        with pytest.raises(NoMatchError) as excinfo:
+            _ = Derived_Type_Stmt(value)
+        assert "Derived_Type_Stmt: '{0}'".format(value) in str(excinfo.value)
+
+
+def test_tostr_1(f2003_create, monkeypatch):
+    '''Check that a derived_type_stmt method tostr() exception is
+    raised if there are an invalid number of items
+
+    '''
+
+    ast = Derived_Type_Stmt("type a")
+    monkeypatch.setattr(ast, "items", ["A"])
+    with pytest.raises(InternalError) as excinfo:
+        str(ast)
+    assert "should be of size 3 but found '1'" in str(excinfo)
+
+
+def test_tostr_2(f2003_create, monkeypatch):
+    '''Check that a derived_type_stmt method tostr() exception is
+    raised.
+
+    '''
+
+    ast = Derived_Type_Stmt("type a")
+    monkeypatch.setattr(ast, "items", [None, None, None])
+    with pytest.raises(InternalError) as excinfo:
+        str(ast)
+    assert ("'Items[1]' should be a Name instance containing the "
+            "derived type name but it is empty") in str(excinfo)
+
+
+def test_get_start_name(f2003_create):
+    '''Check that the appropriate name is returned from
+    get_start_name()
+
+    '''
+    ast = Derived_Type_Stmt("type a")
+    assert ast.get_start_name() == "a"

--- a/src/fparser/two/tests/test_fortran2003.py
+++ b/src/fparser/two/tests/test_fortran2003.py
@@ -561,23 +561,6 @@ def test_logical_literal_constant():  # R428
     assert str(obj) == '.TRUE._HA'
 
 
-def test_derived_type_stmt():  # R430
-
-    tcls = Derived_Type_Stmt
-    obj = tcls('type a')
-    assert isinstance(obj, tcls), repr(obj)
-    assert str(obj) == 'TYPE :: a'
-    assert repr(obj) == "Derived_Type_Stmt(None, Type_Name('a'), None)"
-
-    obj = tcls('type ::a(b,c)')
-    assert isinstance(obj, tcls), repr(obj)
-    assert str(obj) == 'TYPE :: a(b, c)'
-
-    obj = tcls('type, private, abstract::a(b,c)')
-    assert isinstance(obj, tcls), repr(obj)
-    assert str(obj) == 'TYPE, PRIVATE, ABSTRACT :: a(b, c)'
-
-
 def test_type_attr_spec():  # R431
 
     tcls = Type_Attr_Spec


### PR DESCRIPTION
Improves the implementation and tests for derived_type_stmt fortran2003 rule 430. Also fixes the reported bug.