### PR TITLE
Support Empty input files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Modifications by (in alphabetical order):
 * A. R. Porter, Science & Technology Facilities Council, UK
 * P. Vitt, University of Siegen, Germany
 
+28/11/2018 PR #134 for issue #119. Bug fix for parsing files that contain
+           nothing or just white space.
+
 23/11/2018 PR #122 for issue #118. Bug fix for reporting invalid
            Fortran when parsing `use module_name, only:` in fparser2.
 

--- a/doc/fparser2.rst
+++ b/doc/fparser2.rst
@@ -136,6 +136,11 @@ found in the code. Nodes representing in-line comments will be added
 immediately following the node representing the code in which they
 were encountered.
 
+Note that empty input, or input that consists of purely white space
+and/or newlines, is not treated as invalid Fortran and an empty AST is
+returned. Whilst this is not strictly valid, most compilers have this
+behaviour so we follow their lead.
+
 If the code is invalid Fortran then a `FortranSyntaxError` exception
 will be raised which indicates the offending line of code and its line
 number. For example:

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -209,7 +209,9 @@ class Program(BlockBase):  # R201
         try:
             return Base.__new__(cls, string)
         except NoMatchError as error:
-            raise FortranSyntaxError(string, error)
+            # At the moment there is no useful information provided by
+            # NoMatchError so we pass on an empty string.
+            raise FortranSyntaxError(string, "")
 
     @staticmethod
     def match(reader):

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -208,7 +208,7 @@ class Program(BlockBase):  # R201
         '''
         try:
             return Base.__new__(cls, string)
-        except NoMatchError as error:
+        except NoMatchError:
             # At the moment there is no useful information provided by
             # NoMatchError so we pass on an empty string.
             raise FortranSyntaxError(string, "")

--- a/src/fparser/two/tests/fortran2003/test_program_r201.py
+++ b/src/fparser/two/tests/fortran2003/test_program_r201.py
@@ -48,6 +48,10 @@ from fparser.two.Fortran2003 import Program
 
 
 def test_empty_input(f2003_create):
+    '''Test that empty input or input only containing white space can be
+    parsed succesfully
+
+    '''
     for code in ["", "   ", "  \n  \n\n"]:
         reader = get_reader(code)
         ast = Program(reader)

--- a/src/fparser/two/tests/fortran2003/test_program_r201.py
+++ b/src/fparser/two/tests/fortran2003/test_program_r201.py
@@ -32,7 +32,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-'''Test Fortran 2003 rule R201 : This file tests the support for one
+'''Test Fortran 2003 rule R201 : This file tests the support for zero
 or more program-units.
 
 '''
@@ -41,6 +41,17 @@ import pytest
 from fparser.two.utils import FortranSyntaxError
 from fparser.api import get_reader
 from fparser.two.Fortran2003 import Program
+
+# Test no content or just white space. This is not officially a
+# Fortran rule but fortran compilers tend to accept empty content so
+# we follow their lead.
+
+
+def test_empty_input(f2003_create):
+    for code in ["", "   ", "  \n  \n\n"]:
+        reader = get_reader(code)
+        ast = Program(reader)
+        assert str(ast) == ""
 
 # Test single program units
 

--- a/src/fparser/two/utils.py
+++ b/src/fparser/two/utils.py
@@ -80,7 +80,11 @@ class FparserException(Exception):
     '''Base class exception for fparser. This allows an external tool to
     capture all exceptions if required.
 
+    :param str info: a string giving contextual error information.
+
     '''
+    def __init__(self, info):
+        Exception.__init__(self, info)
 
 
 class NoMatchError(FparserException):
@@ -112,18 +116,20 @@ class FortranSyntaxError(FparserException):
                 reader.source_lines[reader.linecount-1])
         if info:
             output += "{0}".format(info)
-        Exception.__init__(self, output)
+        FparserException.__init__(self, output)
 
 
 class InternalError(FparserException):
     '''An exception indicating that an unexpected error has occured in the
     parser.
 
+    :param str info: a string giving contextual error information.
+
     '''
     def __init__(self, info):
         new_info = ("'{0}'. Please report this to the "
                     "authors.".format(info))
-        Exception.__init__(self, new_info)
+        FparserException.__init__(self, new_info)
 
 
 def show_result(func):

--- a/src/fparser/two/utils.py
+++ b/src/fparser/two/utils.py
@@ -296,7 +296,7 @@ class Base(ComparableMixin):
                 # correct (due to coding errors) we can not assume the
                 # line pointed to is the line where the error actually
                 # happened.
-                if string.source_lines[index]:
+                if string.source_lines[index].strip():
                     content = True
                     break
             if not content:


### PR DESCRIPTION
The parser now returns with no error if the input file is empty or only contains white space and/or newlines, rather than raising a SyntaxError or falling over in a heap. Whilst it is probably correct to raise a SyntaxError, a number of compilers allow empty input without complaining so we follow their lead.