### PR TITLE
Fixed bugs in Fortran2003.py: associate-construct, forall-stmt, defin…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ dist/
 .cache/
 .coverage
 fparser.log
+src/fparser.egg-info


### PR DESCRIPTION
Fixed bugs in Fortran2003.py: associate-construct, forall-stmt, defined-operator, and defined-binary-op

associate-construct: renamed Associate_Stmt to Associate_Construct
forall-stmt: revised forall-header pasing part
defined-operator: created a new class for Defined_Operator
defined-binary-op: renamed Defined_Unary_Op to Defined_Binary_Op