### PR TITLE
Executable construct bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Modifications by (in alphabetical order):
 * A. R. Porter, Science & Technology Facilities Council, UK
 * P. Vitt, University of Siegen, Germany
 
+20/12/2018 PR #149 for issue #147. Bug fix that corrects the name of one
+	   of the subclasses (Associate_Construct) of Executable_Construct.
+
 20/12/2018 PR #151 for issue #150 (and part of PR #142). Removes the
 	   triggering of Coveralls from Travis (because it often incorrectly
 	   reports that coverage has decreased).

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -430,18 +430,20 @@ class Specification_Stmt(Base):  # R212
 
 
 class Executable_Construct(Base):  # R213
-    """
-    <executable-construct> = <action-stmt>
-                             | <associate-stmt>
-                             | <case-construct>
-                             | <do-construct>
-                             | <forall-construct>
-                             | <if-construct>
-                             | <select-type-construct>
-                             | <where-construct>
-    """
+    '''
+    Fortran 2003 rule R213
+    executable-construct is action-stmt
+                         or associate-construct
+                         or case-construct
+                         or do-construct
+                         or forall-construct
+                         or if-construct
+                         or select-type-construct
+                         or where-construct
+
+    '''
     subclass_names = [
-        'Action_Stmt', 'Associate_Stmt', 'Case_Construct', 'Comment',
+        'Action_Stmt', 'Associate_Construct', 'Case_Construct',
         'Do_Construct', 'Forall_Construct', 'If_Construct',
         'Select_Type_Construct', 'Where_Construct']
 

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -430,6 +430,7 @@ class Specification_Stmt(Base):  # R212
 
 
 class Executable_Construct(Base):  # R213
+    # pylint: disable=invalid-name
     '''
     Fortran 2003 rule R213
     executable-construct is action-stmt

--- a/src/fparser/two/tests/fortran2003/test_executable_construct_r213.py
+++ b/src/fparser/two/tests/fortran2003/test_executable_construct_r213.py
@@ -43,7 +43,6 @@ subclass tests.
 '''
 
 import pytest
-from fparser.two.utils import NoMatchError
 from fparser.two.Fortran2003 import Executable_Construct
 from fparser.api import get_reader
 

--- a/src/fparser/two/tests/fortran2003/test_executable_construct_r213.py
+++ b/src/fparser/two/tests/fortran2003/test_executable_construct_r213.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2018 Science and Technology Facilities Council
+
+# All rights reserved.
+
+# Modifications made as part of the fparser project are distributed
+# under the following license:
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+'''Test Fortran 2003 rule R213 : This file tests support for the
+Exectuable_Construct class.
+
+As this class just uses Base to match with a choice of subclasses we
+test that an instance of each subclass can be succesfully
+parsed. Detailed checking of the subclass rules are performed by the
+subclass tests.
+
+'''
+
+import pytest
+from fparser.two.utils import NoMatchError
+from fparser.two.Fortran2003 import Executable_Construct
+from fparser.api import get_reader
+
+
+def test_action_statement(f2003_create):
+    '''Test an action statement is supported by the executable construct
+    class.
+
+    '''
+    code = "a = 1.0"
+    result = Executable_Construct(code)
+    assert str(result) == code
+
+
+def test_associate_construct(f2003_create):
+    '''Test an associate construct is supported by the executable
+    construct class.
+
+    '''
+    code = ("associate(a => b)\n"
+            "end associate")
+    reader = get_reader(code)
+    result = Executable_Construct(reader)
+    assert str(result).lower() == code
+
+
+def test_case_construct(f2003_create):
+    '''Test a case construct is supported by the executable construct
+    class.
+
+    '''
+    code = ("select case (a)\n"
+            "end select")
+    reader = get_reader(code)
+    result = Executable_Construct(reader)
+    assert str(result).lower() == code
+
+
+def test_do_construct(f2003_create):
+    '''Test a do construct is supported by the executable construct class.
+
+    '''
+    code = ("do i = 1, n\n"
+            "end do")
+    reader = get_reader(code)
+    result = Executable_Construct(reader)
+    assert str(result).lower() == code
+
+
+@pytest.mark.xfail(reason="Bug in parsing simple forall constructs, see #148")
+def test_forall_construct(f2003_create):
+    '''Test a forall construct is supported by the executable construct
+    class.
+
+    '''
+    # Note, "forall(i = 1 : n, j = 1 : n)" parses correctly.
+    code = ("forall(i = 1 : n)\n"
+            "end forall")
+    reader = get_reader(code)
+    result = Executable_Construct(reader)
+    assert str(result).lower() == code
+
+
+def test_if_construct(f2003_create):
+    '''Test an if construct is supported by the executable construct
+    class.
+
+    '''
+    code = ("if (a) then\n"
+            "end if")
+    reader = get_reader(code)
+    result = Executable_Construct(reader)
+    assert str(result).lower() == code
+
+
+def test_select_type_construct(f2003_create):
+    '''Test a select_type construct is supported by the executable
+    construct class.
+
+    '''
+    code = ("select type(a)\n"
+            "end select")
+    reader = get_reader(code)
+    result = Executable_Construct(reader)
+    assert str(result).lower() == code
+
+
+def test_where_construct(f2003_create):
+    '''Test a where construct is supported by the executable construct
+    class.
+
+    '''
+    code = ("where (a)\n"
+            "end where")
+    reader = get_reader(code)
+    result = Executable_Construct(reader)
+    assert str(result).lower() == code


### PR DESCRIPTION
PR for issue #147 originally provided as a fix in PR #142. This is a simple fix that changes the name of one of the subclasses so that it is now uses the correct rule. I've added associated tests and tidied the class. One of these tests xfails (for a forall loop) and I've added a new issue for this. However, I think this is one of the fixes also found in #142. I've also removed a spurious reference to the Comment class as it is never used (as comments are dealt with in BlockBase).