### PR TITLE
Forall header bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Modifications by (in alphabetical order):
 * A. R. Porter, Science & Technology Facilities Council, UK
 * P. Vitt, University of Siegen, Germany
 
+08/01/2019 PR #152 for #142. Bug fixes for the Fortran 2003 forall header
+           rule (r754).
+
 07/01/2019 PR #158 for #157. Adds support for a Defined Operator (r311 and
            r312).
 

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -4787,13 +4787,13 @@ class Forall_Header(Base):  # pylint: disable=invalid-name
     def match(string):
         '''Implements the matching for a Forall_Header.
 
-        :param str string: a string containing the code to match
-        :return: `None` if there is no match, otherwise a `tuple` of
-                 size 2 containing a class of type
-                 `Forall_Triplet_Spec_List` and a class of type
-                 `Scalar_Mask_Expr` if there is a scalar mask
+        :param str string: A string containing the code to match.
+        :return: `None` if there is no match, otherwise a `tuple` of \
+                 size 2 containing a class of type \
+                 `Forall_Triplet_Spec_List` and a class of type \
+                 `Scalar_Mask_Expr` if there is a scalar mask \
                  expresssion and `None` if not.
-        :rtype: (`Forall_Triplet_Spec_List`, `Scalar_Mask_Expr`) or
+        :rtype: (`Forall_Triplet_Spec_List`, `Scalar_Mask_Expr`) or \
                 (`Forall_Triplet_Spec_List`, `None`) or `None`
 
         '''
@@ -4823,9 +4823,13 @@ class Forall_Header(Base):  # pylint: disable=invalid-name
                     Scalar_Mask_Expr(right_str))
 
     def tostr(self):
-        '''
-        :return: this Forall Header as a string
+        ''':return: this Forall Header as a string
         :rtype: str
+        :raises InternalError: if the length of the internal items \
+        list is not 2.
+        :raises InternalError: if the first entry of the internal \
+        items list has no content, as a Forall_Triplet_List is \
+        expected.
 
         '''
         if len(self.items) != 2:

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -4722,7 +4722,7 @@ class Forall_Construct_Stmt(StmtBase, WORDClsBase):  # R753
         return self.item.name
 
 
-class Forall_Header(Base):  # R754
+class Forall_Header(Base):  # pylint: disable=invalid-name
     '''
     Fortran 2003 rule R754
     forall-header is ( forall-triplet-spec-list [, scalar-mask-expr ] )

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -4723,30 +4723,71 @@ class Forall_Construct_Stmt(StmtBase, WORDClsBase):  # R753
 
 
 class Forall_Header(Base):  # R754
-    """
-    <forall-header> = ( <forall-triplet-spec-list> [ , <scalar-mask-expr> ] )
-    """
+    '''
+    Fortran 2003 rule R754
+    forall-header is ( forall-triplet-spec-list [, scalar-mask-expr ] )
+
+    '''
     subclass_names = []
     use_names = ['Forall_Triplet_Spec_List', 'Scalar_Mask_Expr']
 
     @staticmethod
     def match(string):
-        if not string or string[0] + string[-1] != '()':
-            return
-        line, repmap = string_replace_map(string[1:-1].strip())
-        lst = line.rsplit(',', 1)
-        if len(lst) != 2:
-            return
-        if ':' not in lst[1]:
-            return Forall_Triplet_Spec_List(
-                repmap(lst[0].rstrip())), \
-                Scalar_Mask_Expr(repmap(lst[1].lstrip()))
-        return Forall_Triplet_Spec_List(repmap(line)), None
+        '''Implements the matching for a Forall_Header.
+
+        :param str string: a string containing the code to match
+        :return: `None` if there is no match, otherwise a `tuple` of
+                 size 2 containing a class of type
+                 `Forall_Triplet_Spec_List` and a class of type
+                 `Scalar_Mask_Expr` if there is a scalar mask
+                 expresssion and `None` if not.
+        :rtype: (`Forall_Triplet_Spec_List`, `Scalar_Mask_Expr`) or
+        (`Forall_Triplet_Spec_List`, `None`) or `None`
+
+        '''
+        strip_string = string.strip()
+        if not strip_string:
+            # Input only contains white space
+            return None
+        if strip_string[0] + strip_string[-1] != '()':
+            # Input does not start with '(' and end with ')'
+            return None
+        strip_string_nobr = strip_string[1:-1].strip()
+        try:
+            # first try to match without a scalar mask expression
+            return Forall_Triplet_Spec_List(strip_string_nobr), None
+        except NoMatchError:
+            # The match failed so try to match with the optional
+            # scalar mask expression. Use repmap to remove any
+            # unexpected "," e.g. an array access a(i,j), when
+            # splitting the string.
+            mapped_string, repmap = string_replace_map(strip_string_nobr)
+            split_string = mapped_string.rsplit(',', 1)
+            if len(split_string) != 2:
+                return None
+            left_str = repmap(split_string[0].rstrip())
+            right_str = repmap(split_string[1].lstrip())
+            return (Forall_Triplet_Spec_List(left_str),
+                    Scalar_Mask_Expr(right_str))
 
     def tostr(self):
-        if self.items[1] is None:
-            return '(%s)' % (self.items[0])
-        return '(%s, %s)' % (self.items)
+        '''
+        :return: this Forall Header as a string
+        :rtype: str
+
+        '''
+        if len(self.items) != 2:
+            raise InternalError(
+                "Forall_Header.tostr(). 'items' should be of size 2 but "
+                "found '{0}'.".format(len(self.items)))
+        if not self.items[0]:
+            raise InternalError(
+                "Forall_Header.tostr(). 'items[0]' should be a "
+                "Forall_Triplet_Spec_List instance but it is empty.")
+        if not self.items[1]:
+            # there is no scalar mask expression
+            return "({0})".format(self.items[0])
+        return "({0}, {1})".format(self.items[0], self.items[1])
 
 
 class Forall_Triplet_Spec(Base):  # R755

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -4742,7 +4742,7 @@ class Forall_Header(Base):  # pylint: disable=invalid-name
                  `Scalar_Mask_Expr` if there is a scalar mask
                  expresssion and `None` if not.
         :rtype: (`Forall_Triplet_Spec_List`, `Scalar_Mask_Expr`) or
-        (`Forall_Triplet_Spec_List`, `None`) or `None`
+                (`Forall_Triplet_Spec_List`, `None`) or `None`
 
         '''
         strip_string = string.strip()

--- a/src/fparser/two/tests/fortran2003/test_executable_construct_r213.py
+++ b/src/fparser/two/tests/fortran2003/test_executable_construct_r213.py
@@ -42,7 +42,6 @@ subclass tests.
 
 '''
 
-import pytest
 from fparser.two.Fortran2003 import Executable_Construct
 from fparser.api import get_reader
 

--- a/src/fparser/two/tests/fortran2003/test_executable_construct_r213.py
+++ b/src/fparser/two/tests/fortran2003/test_executable_construct_r213.py
@@ -92,13 +92,11 @@ def test_do_construct(f2003_create):
     assert str(result).lower() == code
 
 
-@pytest.mark.xfail(reason="Bug in parsing simple forall constructs, see #148")
 def test_forall_construct(f2003_create):
     '''Test a forall construct is supported by the executable construct
     class.
 
     '''
-    # Note, "forall(i = 1 : n, j = 1 : n)" parses correctly.
     code = ("forall(i = 1 : n)\n"
             "end forall")
     reader = get_reader(code)

--- a/src/fparser/two/tests/fortran2003/test_forall_header_r754.py
+++ b/src/fparser/two/tests/fortran2003/test_forall_header_r754.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2018 Science and Technology Facilities Council
+
+# All rights reserved.
+
+# Modifications made as part of the fparser project are distributed
+# under the following license:
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+'''Test Fortran 2003 rule R754 : This file tests the support for the
+forall-header statement.
+
+'''
+
+import pytest
+from fparser.api import get_reader
+from fparser.two.Fortran2003 import Forall_Header
+from fparser.two.utils import NoMatchError, InternalError
+
+
+def test_triplet_list(f2003_create):
+    '''Test that one or more triplets is parsed correctly.'''
+    for my_input in ["(i=1:n)",
+                     "  (  i  =  1  :  n  )  ",
+                     "(I=1:N)",
+                     "(i=1:n,j=1:n)",
+                     "(i=1:n:m,j=1:n)",
+                     "(i=1:n,j=1:n:m)",
+                     "(i=1:n:m,j=1:n:m)",
+                     "(i=1:n:m,j=1:n:m,k=1:n:m)",
+                     "(i=a(p,p):n:m,j=1:b(p,p):m,k=1:n:c(p,p))"]:
+        ast = Forall_Header(my_input)
+        assert my_input.replace(" ","") in str(ast).replace(" ","")
+
+
+def test_mask_expr(f2003_create):
+    '''Test that an optional mask expression after a triplet is parsed
+    correctly.
+
+    '''
+    for my_input in ["(i=1:n,i<4)",
+                     "  (  i  =  1  :  n  ,  i  <  4  )  ",
+                     "(I=1:N,I<4)",
+                     "(i=1:n,j=1:n,i/=j)",
+                     "(i=1:n:m,j=1:n,i/=j)",
+                     "(i=1:n,j=1:n:m,i/=j)",
+                     "(i=1:n:m,j=1:n:m,i/=j)",
+                     "(i=1:n:m,j=1:n:m,k=1:n:m,i/=k)",
+                     "(i=1:n:m,j=1:n:m,k=1:n:m,a(i,j,k)==0.0)"]:
+        ast = Forall_Header(my_input)
+        assert my_input.replace(" ","") in str(ast).replace(" ","")
+
+
+def test_parse_error(f2003_create):
+    '''Test that NoMatchError is raised for various syntax errors.'''
+    for my_input in ["",
+                     "  "
+                     "(",
+                     "()",
+                     "i=1:n)",
+                     "(i=1:n",
+                     "(error)"]:
+        with pytest.raises(NoMatchError) as excinfo:
+            _ = Forall_Header(my_input)
+        assert "Forall_Header: '{0}'".format(my_input) in str(excinfo)
+
+
+def test_internal_error1(f2003_create, monkeypatch):
+    '''Check that an internal error is raised if the length of the Items
+    list is not 2 as the str() method assumes that it is.
+
+    '''
+    my_input = "(i=1:2)"
+    ast = Forall_Header(my_input)
+    monkeypatch.setattr(ast, "items", [None, None, None])
+    with pytest.raises(InternalError) as excinfo:
+        str(ast)
+    assert "should be of size 2 but found '3'" in str(excinfo)
+
+
+def test_use_internal_error2(f2003_create, monkeypatch):
+    '''Check that an internal error is raised if the triplet lisy (entry 0
+    of Items) is empty or None as the str() method assumes that it
+    returns a string with content.
+
+    '''
+    my_input = "(i=1:2)"
+    ast = Forall_Header(my_input)
+    for content in [None, ""]:
+        monkeypatch.setattr(ast, "items", [content, None])
+        with pytest.raises(InternalError) as excinfo:
+            str(ast)
+        assert ("'items[0]' should be a Forall_Triplet_Spec_List instance "
+                "but it is empty") in str(excinfo)

--- a/src/fparser/two/tests/fortran2003/test_forall_header_r754.py
+++ b/src/fparser/two/tests/fortran2003/test_forall_header_r754.py
@@ -38,7 +38,6 @@ forall-header statement.
 '''
 
 import pytest
-from fparser.api import get_reader
 from fparser.two.Fortran2003 import Forall_Header
 from fparser.two.utils import NoMatchError, InternalError
 
@@ -55,7 +54,7 @@ def test_triplet_list(f2003_create):
                      "(i=1:n:m,j=1:n:m,k=1:n:m)",
                      "(i=a(p,p):n:m,j=1:b(p,p):m,k=1:n:c(p,p))"]:
         ast = Forall_Header(my_input)
-        assert my_input.replace(" ","") in str(ast).replace(" ","")
+        assert my_input.replace(" ", "") in str(ast).replace(" ", "")
 
 
 def test_mask_expr(f2003_create):
@@ -73,7 +72,7 @@ def test_mask_expr(f2003_create):
                      "(i=1:n:m,j=1:n:m,k=1:n:m,i/=k)",
                      "(i=1:n:m,j=1:n:m,k=1:n:m,a(i,j,k)==0.0)"]:
         ast = Forall_Header(my_input)
-        assert my_input.replace(" ","") in str(ast).replace(" ","")
+        assert my_input.replace(" ", "") in str(ast).replace(" ", "")
 
 
 def test_parse_error(f2003_create):

--- a/src/fparser/two/tests/test_fortran2003.py
+++ b/src/fparser/two/tests/test_fortran2003.py
@@ -2284,18 +2284,6 @@ def test_forall_construct():  # R752
             'n:FORALL(x = 1 : 5 : 2, j = 1 : 4)\n  a(x, j) = j\nEND FORALL n')
 
 
-def test_forall_header():  # R754
-
-    tcls = Forall_Header
-    obj = tcls('(n=1:2, a+1)')
-    assert isinstance(obj, tcls), repr(obj)
-    assert str(obj) == '(n = 1 : 2, a + 1)'
-
-    obj = tcls('(n=1:2, m=1:x-1:z(a))')
-    assert isinstance(obj, tcls), repr(obj)
-    assert str(obj) == '(n = 1 : 2, m = 1 : x - 1 : z(a))'
-
-
 def test_forall_triplet_spec():  # R755
 
     tcls = Forall_Triplet_Spec


### PR DESCRIPTION
Fixes various errors in the fortran 2003 forall header rule r754 and adds appropriate tests.
