### PR TITLE
Allow some statements to preserve their form

### DIFF
--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -832,6 +832,7 @@ class Intrinsic_Type_Spec(WORDClsBase):  # R403
     subclass_names = []
     use_names = ['Kind_Selector', 'Char_Selector']
 
+    @staticmethod
     def match(string):
         for w, cls in [('INTEGER', Kind_Selector),
                        ('REAL', Kind_Selector),
@@ -848,7 +849,6 @@ class Intrinsic_Type_Spec(WORDClsBase):  # R403
             if obj is not None:
                 return obj
         return
-    match = staticmethod(match)
 
 
 class Kind_Selector(Base):  # R404
@@ -1473,6 +1473,7 @@ class End_Type_Stmt(EndStmtBase):  # R433
     """
     subclass_names = []
     use_names = ['Type_Name']
+    stmt_type = "TYPE"
 
     @staticmethod
     def match(string):
@@ -2289,6 +2290,7 @@ class End_Enum_Stmt(EndStmtBase):  # R464
     <end-enum-stmt> = END ENUM
     """
     subclass_names = []
+    stmt_type = "ENUM"
 
     def match(string):
         return EndStmtBase.match('ENUM', None, string, require_stmt_type=True)
@@ -5009,6 +5011,7 @@ class End_Where_Stmt(EndStmtBase):  # R751
     """
     subclass_names = []
     use_names = ['Where_Construct_Name']
+    stmt_type = "WHERE"
 
     @staticmethod
     def match(string):
@@ -5178,6 +5181,7 @@ class End_Forall_Stmt(EndStmtBase):  # R758
     """
     subclass_names = []
     use_names = ['Forall_Construct_Name']
+    stmt_type = "FORALL"
 
     @staticmethod
     def match(string):
@@ -5387,6 +5391,7 @@ class Else_Stmt(StmtBase):  # R805
     """
     subclass_names = []
     use_names = ['If_Construct_Name']
+    stmt_type = "ELSE"
 
     @staticmethod
     def match(string):
@@ -5414,6 +5419,7 @@ class End_If_Stmt(EndStmtBase):  # R806
     """
     subclass_names = []
     use_names = ['If_Construct_Name']
+    stmt_type = "IF"
 
     @staticmethod
     def match(string):
@@ -5550,6 +5556,7 @@ class End_Select_Stmt(EndStmtBase):  # R811
     """
     subclass_names = []
     use_names = ['Case_Construct_Name']
+    stmt_type = "SELECT"
 
     @staticmethod
     def match(string):
@@ -5676,6 +5683,7 @@ class End_Associate_Stmt(EndStmtBase):  # R820
     """
     subclass_names = []
     use_names = ['Associate_Construct_Name']
+    stmt_type = "ASSOCIATE"
 
     @staticmethod
     def match(string):
@@ -5806,6 +5814,7 @@ class End_Select_Type_Stmt(EndStmtBase):  # R824
     """
     subclass_names = []
     use_names = ['Select_Construct_Name']
+    stmt_type = "SELECT"
 
     @staticmethod
     def match(string):
@@ -6119,6 +6128,7 @@ class End_Do_Stmt(EndStmtBase):  # pylint: disable=invalid-name
     """
     subclass_names = []
     use_names = ['Do_Construct_Name']
+    stmt_type = "DO"
 
     @staticmethod
     def match(string):
@@ -8469,6 +8479,7 @@ class End_Program_Stmt(EndStmtBase):  # R1103
     """
     subclass_names = []
     use_names = ['Program_Name']
+    stmt_type = "PROGRAM"
 
     @staticmethod
     def match(string):
@@ -8499,6 +8510,7 @@ class Module_Stmt(StmtBase, WORDClsBase):  # R1105
     """
     subclass_names = []
     use_names = ['Module_Name']
+    stmt_type = "MODULE"
 
     @staticmethod
     def match(string):
@@ -8515,6 +8527,7 @@ class End_Module_Stmt(EndStmtBase):  # R1106
     """
     subclass_names = []
     use_names = ['Module_Name']
+    stmt_type = "MODULE"
 
     @staticmethod
     def match(string):
@@ -8789,6 +8802,7 @@ class Block_Data_Stmt(StmtBase):  # R1117
     """
     subclass_names = []
     use_names = ['Block_Data_Name']
+    stmt_type = "BLOCK DATA"
 
     @staticmethod
     def match(string):
@@ -8818,6 +8832,7 @@ class End_Block_Data_Stmt(EndStmtBase):  # R1118
     """
     subclass_names = []
     use_names = ['Block_Data_Name']
+    stmt_type = "BLOCK DATA"
 
     @staticmethod
     def match(string):
@@ -8899,6 +8914,7 @@ items : (Generic_Spec, )
     """
     subclass_names = []
     use_names = ['Generic_Spec']
+    stmt_type = "INTERFACE"
 
     def match(string):
         return EndStmtBase.match(
@@ -9210,11 +9226,11 @@ class Intrinsic_Stmt(StmtBase, WORDClsBase):  # R1216
     subclass_names = []
     use_names = ['Intrinsic_Procedure_Name_List']
 
+    @staticmethod
     def match(string):
         return WORDClsBase.match(
             'INTRINSIC', Intrinsic_Procedure_Name_List,
             string, check_colons=True, require_cls=True)
-    match = staticmethod(match)
     tostr = WORDClsBase.tostr_a
 
 
@@ -9504,6 +9520,7 @@ class End_Function_Stmt(EndStmtBase):  # R1230
     """
     subclass_names = []
     use_names = ['Function_Name']
+    stmt_type = "FUNCTION"
 
     def match(string):
         return EndStmtBase.match('FUNCTION', Function_Name, string)
@@ -9602,6 +9619,7 @@ class End_Subroutine_Stmt(EndStmtBase):  # R1234
     """
     subclass_names = []
     use_names = ['Subroutine_Name']
+    stmt_type = "SUBROUTINE"
 
     @staticmethod
     def match(string):

--- a/src/fparser/two/Fortran2008.py
+++ b/src/fparser/two/Fortran2008.py
@@ -320,6 +320,7 @@ class End_Submodule_Stmt(EndStmtBase):  # R1119
     '''
     subclass_names = []
     use_names = ['Submodule_Name']
+    stmt_type = "SUBMODULE"
 
     @staticmethod
     def match(fstring):
@@ -333,18 +334,6 @@ class End_Submodule_Stmt(EndStmtBase):  # R1119
 
         '''
         return EndStmtBase.match('SUBMODULE', Submodule_Name, fstring)
-
-    def get_name(self):  # C1114
-        '''Fortran 2008 constraint C1114 return the submodule name as
-        specified by the end submodule statement or `None` if one is
-        not specified. This is used by the base class to check whether
-        this name matches the submodule name.
-
-        :return: the name of the submodule stored in a Name class
-        :return type: :py:class:`fparser.two.Fortran2003.Name` or `None`
-
-        '''
-        return self.items[1]
 
 
 class Parent_Identifier(Base):  # R1118 (C1113)

--- a/src/fparser/two/tests/fortran2003/test_cray_pointer_stmt.py
+++ b/src/fparser/two/tests/fortran2003/test_cray_pointer_stmt.py
@@ -52,7 +52,7 @@ def test_cray_pointer_stmt(f2003_create):
         '''Internal helper function to avoid code replication.'''
         ast = Cray_Pointer_Stmt(reader)
         assert "POINTER(a, b)" in str(ast)
-        assert repr(ast) == ("Cray_Pointer_Stmt('POINTER', Cray_Pointer_Decl"
+        assert repr(ast) == ("Cray_Pointer_Stmt('pointer', Cray_Pointer_Decl"
                              "(Name('a'), Name('b')))")
 
     line = "pointer (a, b)"

--- a/src/fparser/two/tests/fortran2003/test_main_program_r1101.py
+++ b/src/fparser/two/tests/fortran2003/test_main_program_r1101.py
@@ -59,15 +59,15 @@ def test_valid(f2003_create):
     obj = Main_Program(get_reader("program a\nend"))
     assert isinstance(obj, Main_Program)
     assert str(obj) == 'PROGRAM a\nEND PROGRAM a'
-    assert repr(obj) == ("Main_Program(Program_Stmt('PROGRAM', Name('a')), "
-                         "End_Program_Stmt('PROGRAM', None))")
+    assert repr(obj) == ("Main_Program(Program_Stmt('program', Name('a')), "
+                         "End_Program_Stmt('end', None))")
 
     # name matching
     obj = Main_Program(get_reader("program a\nend program a"))
     assert isinstance(obj, Main_Program)
     assert str(obj) == 'PROGRAM a\nEND PROGRAM a'
-    assert repr(obj) == ("Main_Program(Program_Stmt('PROGRAM', Name('a')), "
-                         "End_Program_Stmt('PROGRAM', Name('a')))")
+    assert repr(obj) == ("Main_Program(Program_Stmt('program', Name('a')), "
+                         "End_Program_Stmt('end program', Name('a')))")
 
     # mixed case name matching
     obj = Main_Program(get_reader("program a\nend program A"))

--- a/src/fparser/two/tests/fortran2003/test_program_stmt_r1102.py
+++ b/src/fparser/two/tests/fortran2003/test_program_stmt_r1102.py
@@ -48,7 +48,7 @@ def test_valid(f2003_create):
     obj = Program_Stmt("program a")
     assert isinstance(obj, Program_Stmt)
     assert str(obj) == 'PROGRAM a'
-    assert repr(obj) == "Program_Stmt('PROGRAM', Name('a'))"
+    assert repr(obj) == "Program_Stmt('program', Name('a'))"
 
 
 def test_invalid(f2003_create):

--- a/src/fparser/two/tests/fortran2008/test_submodule_r1116.py
+++ b/src/fparser/two/tests/fortran2008/test_submodule_r1116.py
@@ -47,10 +47,16 @@
 
 '''
 
+import textwrap
+
 import pytest
 from fparser.api import get_reader
 from fparser.two.utils import NoMatchError
 from fparser.two.Fortran2008 import Submodule
+
+
+def prep_expected(expected):
+    return textwrap.dedent(expected).strip()
 
 
 def test_submodule(f2008_create):
@@ -93,11 +99,14 @@ def test_submodule_msp(f2008_create):
       end
       ''')
     ast = Submodule(reader)
-    assert "SUBMODULE (foobar) bar\n" \
-        "  CONTAINS\n" \
-        "  SUBROUTINE info\n" \
-        "  END SUBROUTINE info\n" \
-        "END SUBMODULE bar" in str(ast)
+    expected = """
+        SUBMODULE (foobar) bar
+          CONTAINS
+          SUBROUTINE info
+          END SUBROUTINE info
+        END SUBMODULE bar
+    """
+    assert prep_expected(expected) == str(ast)
 
 
 def test_submodule_both(f2008_create):
@@ -114,12 +123,15 @@ def test_submodule_both(f2008_create):
       end
       ''')
     ast = Submodule(reader)
-    assert "SUBMODULE (foobar) bar\n" \
-        "  USE empty\n" \
-        "  CONTAINS\n" \
-        "  SUBROUTINE info\n" \
-        "  END SUBROUTINE info\n" \
-        "END SUBMODULE bar" in str(ast)
+    expected = """
+        SUBMODULE (foobar) bar
+          USE empty
+          CONTAINS
+          SUBROUTINE info
+          END SUBROUTINE info
+        END SUBMODULE bar
+    """
+    assert prep_expected(expected) == str(ast)
 
 # constraint C1112 format statement
 

--- a/src/fparser/two/tests/test_fortran2003.py
+++ b/src/fparser/two/tests/test_fortran2003.py
@@ -109,7 +109,7 @@ def test_specification_part():
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'INTEGER :: a'
     assert (repr(obj) == "Specification_Part(Type_Declaration_Stmt("
-            "Intrinsic_Type_Spec('INTEGER', None), None, "
+            "Intrinsic_Type_Spec('integer', None), None, "
             "Entity_Decl(Name('a'), None, None, None)))")
 
     obj = tcls(get_reader('''\
@@ -554,7 +554,7 @@ def test_end_type_stmt():  # R433
     obj = tcls('end type')
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'END TYPE'
-    assert repr(obj) == "End_Type_Stmt('TYPE', None)"
+    assert repr(obj) == "End_Type_Stmt('end type', None)"
 
     obj = tcls('end type  a')
     assert isinstance(obj, tcls), repr(obj)
@@ -720,7 +720,7 @@ def test_final_binding():  # R454
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'FINAL :: a, b'
     assert (repr(obj) ==
-            "Final_Binding('FINAL', Final_Subroutine_Name_List(',', "
+            "Final_Binding('final', Final_Subroutine_Name_List(',', "
             "(Name('a'), Name('b'))))")
 
     obj = tcls('final::a')
@@ -907,7 +907,7 @@ def test_ac_spec():  # R466
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'INTEGER ::'
     assert (repr(obj) ==
-            "Ac_Spec(Intrinsic_Type_Spec('INTEGER', None), None)")
+            "Ac_Spec(Intrinsic_Type_Spec('integer', None), None)")
 
     obj = tcls('integer :: a,b')
     assert isinstance(obj, tcls), repr(obj)
@@ -973,7 +973,7 @@ def test_type_declaration_stmt():  # R501
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'INTEGER :: a'
     assert (repr(obj) ==
-            "Type_Declaration_Stmt(Intrinsic_Type_Spec('INTEGER', None), "
+            "Type_Declaration_Stmt(Intrinsic_Type_Spec('integer', None), "
             "None, Entity_Decl(Name('a'), None, None, None))")
 
     obj = tcls('integer ,dimension(2):: a*3')
@@ -984,7 +984,7 @@ def test_type_declaration_stmt():  # R501
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'REAL :: a'
     assert (repr(obj) ==
-            "Type_Declaration_Stmt(Intrinsic_Type_Spec('REAL', None), "
+            "Type_Declaration_Stmt(Intrinsic_Type_Spec('real', None), "
             "None, Entity_Decl(Name('a'), None, None, None))")
 
     obj = tcls('REAL A( LDA, * ), B( LDB, * )')
@@ -1197,7 +1197,7 @@ def test_access_stmt():  # R518
     obj = tcls('private')
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'PRIVATE'
-    assert repr(obj) == "Access_Stmt('PRIVATE', None)"
+    assert repr(obj) == "Access_Stmt('private', None)"
 
     obj = tcls('public a,b')
     assert isinstance(obj, tcls), repr(obj)
@@ -1281,13 +1281,13 @@ def test_optional_stmt():  # R537
     obj = tcls('optional :: a')
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'OPTIONAL :: a'
-    assert repr(obj) == "Optional_Stmt('OPTIONAL', Name('a'))"
+    assert repr(obj) == "Optional_Stmt('optional', Name('a'))"
 
     obj = tcls('optional :: a, b, c')
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'OPTIONAL :: a, b, c'
     assert (repr(obj) ==
-            "Optional_Stmt('OPTIONAL', Dummy_Arg_Name_List(',', (Name('a'), "
+            "Optional_Stmt('optional', Dummy_Arg_Name_List(',', (Name('a'), "
             "Name('b'), Name('c'))))")
 
 
@@ -1327,7 +1327,7 @@ def test_pointer_stmt():  # R540
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'POINTER :: a(:), b'
     assert (repr(obj) ==
-            "Pointer_Stmt('POINTER', Pointer_Decl_List(',', (Pointer_Decl("
+            "Pointer_Stmt('pointer', Pointer_Decl_List(',', (Pointer_Decl("
             "Name('a'), Deferred_Shape_Spec(None, None)), Name('b'))))")
 
 
@@ -1352,13 +1352,13 @@ def test_protected_stmt():  # R542
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'PROTECTED :: a, b'
     assert (repr(obj) ==
-            "Protected_Stmt('PROTECTED', Entity_Name_List(',', (Name('a'), "
+            "Protected_Stmt('protected', Entity_Name_List(',', (Name('a'), "
             "Name('b'))))")
 
     obj = tcls('protected ::a')
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'PROTECTED :: a'
-    assert repr(obj) == "Protected_Stmt('PROTECTED', Name('a'))"
+    assert repr(obj) == "Protected_Stmt('protected', Name('a'))"
 
 
 def test_save_stmt():  # R543
@@ -1367,19 +1367,19 @@ def test_save_stmt():  # R543
     obj = tcls('save')
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'SAVE'
-    assert repr(obj) == "Save_Stmt('SAVE', None)"
+    assert repr(obj) == "Save_Stmt('save', None)"
 
     obj = tcls('save a, b')
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'SAVE :: a, b'
-    assert (repr(obj) == "Save_Stmt('SAVE', "
+    assert (repr(obj) == "Save_Stmt('save', "
             "Saved_Entity_List(',', (Name('a'), Name('b'))))")
 
     obj = tcls('save :: /a/ , b')
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'SAVE :: /a/, b'
     assert (repr(obj) ==
-            "Save_Stmt('SAVE', Saved_Entity_List(',', (Saved_Entity('/', "
+            "Save_Stmt('save', Saved_Entity_List(',', (Saved_Entity('/', "
             "Name('a'), '/'), Name('b'))))")
 
 
@@ -1457,7 +1457,7 @@ def test_implicit_spec():  # R550
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'INTEGER(A - Z)'
     assert (repr(obj) ==
-            "Implicit_Spec(Intrinsic_Type_Spec('INTEGER', None), "
+            "Implicit_Spec(Intrinsic_Type_Spec('integer', None), "
             "Letter_Spec('A', 'Z'))")
 
     obj = tcls('double  complex (r,d-g)')
@@ -1496,7 +1496,7 @@ def test_equivalence_stmt():  # R554
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'EQUIVALENCE(a, b, z)'
     assert (repr(obj) ==
-            "Equivalence_Stmt('EQUIVALENCE', Equivalence_Set(Name('a'), "
+            "Equivalence_Stmt('equivalence', Equivalence_Set(Name('a'), "
             "Equivalence_Object_List(',', (Name('b'), Name('z')))))")
 
     obj = tcls('equivalence (a, b ,z),(b,l)')
@@ -3892,7 +3892,7 @@ def test_function_subprogram():  # R1223
     assert str(obj) == 'FUNCTION foo()\nEND FUNCTION foo'
     assert (repr(obj) ==
             "Function_Subprogram(Function_Stmt(None, Name('foo'), None, None),"
-            " End_Function_Stmt('FUNCTION', Name('foo')))")
+            " End_Function_Stmt('end function', Name('foo')))")
 
     reader = get_reader('''\
     pure real function foo(a) result(b) bind(c)
@@ -4039,7 +4039,7 @@ def test_subroutine_subprogram():  # R1231
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'SUBROUTINE foo\nEND SUBROUTINE foo'
     assert (repr(obj) == "Subroutine_Subprogram(Subroutine_Stmt(None, "
-            "Name('foo'), None, None), End_Subroutine_Stmt('SUBROUTINE', "
+            "Name('foo'), None, None), End_Subroutine_Stmt('end subroutine', "
             "Name('foo')))")
 
     reader = get_reader('''\
@@ -4106,7 +4106,7 @@ def test_end_subroutine_stmt():  # R1234
     obj = tcls('end subroutine foo')
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'END SUBROUTINE foo'
-    assert repr(obj) == "End_Subroutine_Stmt('SUBROUTINE', Name('foo'))"
+    assert repr(obj) == "End_Subroutine_Stmt('end subroutine', Name('foo'))"
 
     obj = tcls('end')
     assert isinstance(obj, tcls), repr(obj)

--- a/src/fparser/two/tests/utils/test_blockbase.py
+++ b/src/fparser/two/tests/utils/test_blockbase.py
@@ -75,15 +75,15 @@ def test_include(f2003_create):
     result = BlockBase.match(startcls, subclasses, endcls, reader)
     assert (
         "([Include_Stmt(Include_Filename('1')), Comment('! comment1'), "
-        "Program_Stmt('PROGRAM', Name('test')), Specification_Part("
+        "Program_Stmt('program', Name('test')), Specification_Part("
         "Implicit_Part(Include_Stmt(Include_Filename('2')), Comment("
-        "'! comment2')), Type_Declaration_Stmt(Intrinsic_Type_Spec('INTEGER'"
+        "'! comment2')), Type_Declaration_Stmt(Intrinsic_Type_Spec('integer'"
         ", None), None, Entity_Decl(Name('i'), None, None, None)), "
         "Implicit_Part(Include_Stmt(Include_Filename('3')), Comment("
         "'! comment3'))), Execution_Part(Assignment_Stmt(Name('i'), '=', "
         "Int_Literal_Constant('1', None)), Include_Stmt(Include_Filename('4'))"
         ", Comment('! comment4')), Internal_Subprogram_Part(Contains_Stmt("
         "'CONTAINS'), Include_Stmt(Include_Filename('5')), Comment("
-        "'! comment5')), End_Program_Stmt('PROGRAM', Name('test'))],)") \
+        "'! comment5')), End_Program_Stmt('end program', Name('test'))],)") \
         in str(result)
     assert "should" not in str(result)

--- a/src/fparser/two/tests/utils/test_wordclsbase.py
+++ b/src/fparser/two/tests/utils/test_wordclsbase.py
@@ -74,7 +74,7 @@ def test_wordclsbase():
     # token only, mixed case match
     text = "ToKeN"
     result = WORDClsBase.match(token, Name, text)
-    assert str(result) == "('{0}', None)".format(token)
+    assert str(result) == "('{0}', None)".format(text)
 
     # token only, spaces match
     text = "  {0}  ".format(token)


### PR DESCRIPTION
In order to build other tools that make use of fparser it is sometimes desirable to be able to output *approximately* similar code to the input (where "approximately" is not well defined, but on the whole is whitespace insensitive). For this we really want the parse tree, not an AST. The ``fparser.two`` code actually gets pretty close to a parse tree (for example it preserves comments), but it does stray into the AST territory in a number of places (reasonably so, as you definitely want to be doing PSyclone like transformations on an AST-like form, not a parse-tree). What is quite pleasing about the fparser parser is that one can see the class structure as the "abstract tree", while the *contents* of the object are much closer to a parse-tree.

With the following change, I preserve the form that is parsed using ``WORDClsBase`` and ``EndStmtBase``, and treat capitalisation as a transformation that (automatically) takes place once you ``tostr()`` it. Whilst this does not cover everything (USE, CONTAINS, intrinsic types, etc.), it is a significant chunk of the obvious changes that get applied, and allows one to start writing code that can handle the *untransformed* form (example collapsed below).

<details>
 <summary>Example of how to visit the program and produce (mostly) non-capitalised form</summary>

```
from fparser.two.utils import EndStmtBase


def children(node):
    """Get the immediate children of the given node."""
    children = getattr(node, 'content', None)
    if children is None:
        children = getattr(node, 'items', None)
    return children


class Visitor:
    def __init__(self, program):
        self.lines = []
        self.visit(program)

    def find_visitor_method(self, node):
        for cls in type(node).mro():
            method = getattr(self, f'visit_{cls.__name__}', None)
            if method:
                break
        return method

    def visit(self, node, indentation=''):
        method = self.find_visitor_method(node)
        print('Visiting {} with {}'.format(type(node).__name__, method.__name__))
        method(node, indentation=indentation)

    def visit_object(self, node, indentation=''):
        # This is the "fallback"/"generic" implementation that will be
        # called if there are no more specific visitor methods.
        for child in children(node) or []:
            self.visit(child)

    def visit_BlockBase(self, node, indentation=''):
        nodes = children(node)
        has_end = isinstance(nodes[-1], EndStmtBase)

        if has_end:
            mid_indentation = '  ' + indentation
        else:
            mid_indentation = indentation

        self.visit(nodes[0], indentation=indentation)
        for n in nodes[1:-1]:
            self.visit(n, mid_indentation)
        if len(nodes) > 1:
            self.visit(nodes[-1], indentation=indentation)

        if has_end and not indentation:
            # Insert an empty line after top level end statements.
            self.lines.append('')

    def visit_StmtBase(self, node, indentation=''):
        # Default behaviour for all statements is to use their str repr.
        if ':' in str(node) or not children(node):
            self.stringify_node(node, indentation=indentation)
        else:
            self.stringify_node_items(node, indentation=indentation)

    def stringify_node(self, node, indentation=''):
        self.lines.append(indentation + str(node))

    def stringify_node_items(self, node, indentation=''):
        # In some cases we'd prefer to iterate through a node's items and
        # print those instead.
        self.lines.append(indentation + ' '.join(
            str(item) for item in node.items if item is not None))

    visit_Subroutine_Stmt = stringify_node
    visit_Submodule_Stmt = stringify_node
    visit_Implicit_Part = stringify_node
```

This can be used with:

```
from fparser.two.parser import ParserFactory
from fparser.common.readfortran import FortranStringReader


code = """
program main
use foobar, only : foo
integer a
a = 2
end program main

module hello
contains
subroutine foobar
implicit none
real :: a
a = 3.14
end subroutine foobar
end module hello

submodule (hello2) world
end submodule world
subroutine world2
end subroutine world2
"""

parser = ParserFactory().create(std="f2008")
program = parser(FortranStringReader(code))

visitor = Visitor(program)
print()
print('\n'.join(visitor.lines))
```

</details>

---------

In this implementation I have *not* added further tests as the work isn't really complete, and the existing testing ensures that the AST/``.tostr()`` is correct. There is more work to be done to preserve more of the original source, and at that point I can start to add further tests. Given this is self-contained work, I propose that this be done in a separate PR.

I'm not striving to get fparser to the point where it can write back out exactly the form that was read - I've taken the pragmatic approach where some of the big-ticket items *can* be preserved (like case). As an example of this, I have no intention of making fparser preserve whitespace/indentation.

An interesting case popped up that meant I needed to add more data to the parse-tree of ``EndStmtBase``, as the parser adds the name from the opening block if it doesn't have one explicitly from the source. This causes a bit of an issue if the source only has ``end`` (without the end statement type), as it isn't valid Fortran to ``end <name>``.

In order to try to reduce the noise on this PR, I have not:

 * make the ``match`` static method a class method so that I can share the ``statement_type`` definition (todo in another PR)
 * tidied up all of the string tests to use the improved ``prepare_expected`` helper, which dramatically improves the test failure output **and** readability of the code in the first place (todo in another PR) 