### PR TITLE
WIP: Addition of a EndStmtBase test case using 'block data' which currently fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,15 @@ Modifications by (in alphabetical order):
 * A. R. Porter, Science & Technology Facilities Council, UK
 * P. Vitt, University of Siegen, Germany
 
+14/06/2019 PR #181. Added an xfailing test to demonstrate an error in EndStmtBase.
+
 14/06/2019 PR #196. Fix for unicode input errors in Python.
 
 14/06/2019 PR #194. Fix for unicode input errors in Python 3.6.
 
 05/04/2019 PR #192. END statements which use class EndStmtBase now output
 	   the same tokens as the input e.g. names are not added if they
-	   don't exist in the input.
+	do	n't exist in the input.
 
 29/03/2019 Issue #167 and PR #182. Fix to Fortran2003 rule 701 where large
            codes were causing recurse-depth errors in Python.

--- a/src/fparser/two/tests/test_fortran2003.py
+++ b/src/fparser/two/tests/test_fortran2003.py
@@ -3560,6 +3560,14 @@ end block data
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == 'BLOCK DATA a\n  REAL :: b\nEND BLOCK DATA a'
 
+    tcls = Block_Data
+    obj = tcls(get_reader('''\
+block     data a
+end block     data a
+    '''))
+    assert isinstance(obj, tcls), repr(obj)
+    assert str(obj) == 'BLOCK DATA a\nEND BLOCK DATA a'
+
 #
 # SECTION 12
 #

--- a/src/fparser/two/tests/test_fortran2003.py
+++ b/src/fparser/two/tests/test_fortran2003.py
@@ -3549,6 +3549,7 @@ def test_rename():  # R1111
     assert str(obj) == 'OPERATOR(.FOO.) => OPERATOR(.BAR.)'
 
 
+@pytest.mark.xfail(reason="Match fails with multiple spaces, see issue #197")
 def test_block_data():  # R1116
 
     tcls = Block_Data


### PR DESCRIPTION
Currently there is no testing for end statements for types with multiple spaces in them (applies to "BLOCK DATA").

The code that will need testing/fixing is at https://github.com/stfc/fparser/blob/fc79f65/src/fparser/two/utils.py#L1188.