### PR TITLE
Fix parsing of large arrays

### DIFF
--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -9762,7 +9762,6 @@ class %s_List(SequenceBase):
 class %s_Name(Base):
     subclass_names = [\'Name\']
 ''' % (n))
-            print('CREATED:', n)
         elif n.startswith('Scalar_'):
             _names.append(n)
             n = n[7:]
@@ -9770,4 +9769,5 @@ class %s_Name(Base):
 class Scalar_%s(Base):
     subclass_names = [\'%s\']
 ''' % (n, n))
+
 # EOF

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -4323,9 +4323,9 @@ class Primary(Base):  # R701
                 | ( <expr> )
     """
     subclass_names = [
-        'Constant', 'Parenthesis', 'Designator', 'Array_Constructor',
+        'Constant', 'Designator', 'Array_Constructor', 
         'Structure_Constructor', 'Function_Reference',
-        'Type_Param_Inquiry', 'Type_Param_Name',
+        'Type_Param_Inquiry', 'Type_Param_Name', 'Parenthesis',
     ]
 
 

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -9762,6 +9762,7 @@ class %s_List(SequenceBase):
 class %s_Name(Base):
     subclass_names = [\'Name\']
 ''' % (n))
+            print('CREATED:', n)
         elif n.startswith('Scalar_'):
             _names.append(n)
             n = n[7:]
@@ -9769,5 +9770,4 @@ class %s_Name(Base):
 class Scalar_%s(Base):
     subclass_names = [\'%s\']
 ''' % (n, n))
-
 # EOF

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -4313,17 +4313,20 @@ class Scalar_Char_Initialization_Expr(Base):
 
 class Primary(Base):  # R701
     """
-    <primary> = <constant>
-                | <designator>
-                | <array-constructor>
-                | <structure-constructor>
-                | <function-reference>
-                | <type-param-inquiry>
-                | <type-param-name>
-                | ( <expr> )
+    Fortran 2003 rule R701
+
+    primary is constant
+            or designator
+            or array-constructor
+            or structure-constructor
+            or function-reference
+            or type-param-inquiry
+            or type-param-name
+            or ( expr )
+
     """
     subclass_names = [
-        'Constant', 'Designator', 'Array_Constructor', 
+        'Constant', 'Designator', 'Array_Constructor',
         'Structure_Constructor', 'Function_Reference',
         'Type_Param_Inquiry', 'Type_Param_Name', 'Parenthesis',
     ]

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -4312,7 +4312,7 @@ class Scalar_Char_Initialization_Expr(Base):
 
 
 class Primary(Base):  # R701
-    """
+    '''
     Fortran 2003 rule R701
 
     primary is constant
@@ -4324,7 +4324,7 @@ class Primary(Base):  # R701
             or type-param-name
             or ( expr )
 
-    """
+    '''
     subclass_names = [
         'Constant', 'Designator', 'Array_Constructor',
         'Structure_Constructor', 'Function_Reference',

--- a/src/fparser/two/tests/fortran2003/test_primary_r701.py
+++ b/src/fparser/two/tests/fortran2003/test_primary_r701.py
@@ -129,7 +129,7 @@ def test_Structure_Constructor(f2003_create):
         expected_str='PERSON(12, "Jones")')
 
 
-@pytest.mark.xfail(reason="Unable to reach Function_Reference when parsing")
+@pytest.mark.xfail(reason="Requires more parse context (#190)")
 def test_Function_Reference(f2003_create):
     '''This test demonstrates the inability to distinguish
     Structure_Constructor from Function_Reference without more parse context
@@ -139,7 +139,7 @@ def test_Function_Reference(f2003_create):
         'a_function(1.2, some_kwarg="hello")', f2003.Function_Reference)
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(reason="Requires more parse context (#190)")
 def test_Type_Param_Inquiry():
     '''This test demonstrates the inability to distinguish Designator from
     Type_Param_Inquiry without more parse context than is currently being
@@ -174,7 +174,7 @@ def test_no_match(f2003_create):
         obj = f2003.Primary('! A comment')
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(reason="Requires more parse context (#190)")
 def test_C701_no_assumed_size_array(f2003_create):
     '''Test C701 (R701) The type-param-name shall be the name of a type.
     This test cannot be passed without more parse context of things like
@@ -185,7 +185,7 @@ def test_C701_no_assumed_size_array(f2003_create):
         f2003.Primary('not_a_type',)  # context)
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(reason="Requires more parse context (#190)")
 def test_C702_no_assumed_size_array(f2003_create):
     '''Test C702 (R701) The designator shall not be a whole assumed-size array.
     This test cannot be passed without more parse context of things like

--- a/src/fparser/two/tests/fortran2003/test_primary_r701.py
+++ b/src/fparser/two/tests/fortran2003/test_primary_r701.py
@@ -42,33 +42,30 @@ import fparser.two.utils
 
 
 # A list of [Expression, Expected Type, ToString] for the test cases.
-cases = [
-    ['1.2e-03', f2003.Real_Literal_Constant, '1.2E-03'],
-    ['(1, n)', f2003.Complex_Literal_Constant, '(1, n)'],
-    ['.true.', f2003.Logical_Literal_Constant, '.TRUE.'],
-    ['"hey a()c"', f2003.Char_Literal_Constant, '"hey a()c"'],
-    ['b"0101"', f2003.Binary_Constant, 'B"0101"'],
+SUBCLASS_CASES = [
+    ['1.2e-03', f2003.Real_Literal_Constant, '1.2E-03'],  # Constructor
 
-    ['o"0107"', f2003.Octal_Constant, 'O"0107"'],
-    ['z"a107"', f2003.Hex_Constant, 'Z"A107"'],
-    ['a%b', f2003.Data_Ref, 'a % b'],
-    ['[ 1.2, 2.3e+2, -5.1e-3 ]', f2003.Array_Constructor,
+    ['a%b', f2003.Data_Ref, 'a % b'],  # Designator
+    ['[ 1.2, 2.3e+2, -5.1e-3 ]', f2003.Array_Constructor,  # Array constructor
      '[1.2, 2.3E+2, - 5.1E-3]'],
     ['PERSON  (12,  "Jones")', f2003.Part_Ref,
-     'PERSON(12, "Jones")'],
-    ['a', f2003.Name, 'a'],
-    ['(a)', f2003.Parenthesis, '(a)'],
-    ['(a +  b)', f2003.Parenthesis, '(a + b)'],
+     'PERSON(12, "Jones")'],  # Structure constructor
+    ['a', f2003.Name, 'a'],  # Type param name
+    ['(a +  b)', f2003.Parenthesis, '(a + b)'], # Parenthesis (expr)
 ]
 
 
-@pytest.mark.parametrize('source, expected_type, to_str', cases)
+@pytest.mark.parametrize('source, expected_type, to_str', SUBCLASS_CASES)
 def test_primary_subclasses(f2003_create, source, expected_type, to_str):
+    '''
+    '''
     obj = f2003.Primary(source)
     assert type(obj) == expected_type
     assert str(obj) == to_str
 
 
 def test_no_match(f2003_create):
+    '''
+    '''
     with pytest.raises(fparser.two.utils.NoMatchError):
         obj = f2003.Primary('! A comment')

--- a/src/fparser/two/tests/fortran2003/test_primary_r701.py
+++ b/src/fparser/two/tests/fortran2003/test_primary_r701.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2019 Science and Technology Facilities Council
+
+# All rights reserved.
+
+# Modifications made as part of the fparser project are distributed
+# under the following license:
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+'''Test Fortran 2003 rule R701 : primary type.
+
+'''
+import pytest
+
+import fparser.two.Fortran2003 as f2003
+import fparser.two.utils
+
+
+# A list of [Expression, Expected Type, ToString] for the test cases.
+cases = [
+    ['1.2e-03', f2003.Real_Literal_Constant, '1.2E-03'],
+    ['(1, n)', f2003.Complex_Literal_Constant, '(1, n)'],
+    ['.true.', f2003.Logical_Literal_Constant, '.TRUE.'],
+    ['"hey a()c"', f2003.Char_Literal_Constant, '"hey a()c"'],
+    ['b"0101"', f2003.Binary_Constant, 'B"0101"'],
+
+    ['o"0107"', f2003.Octal_Constant, 'O"0107"'],
+    ['z"a107"', f2003.Hex_Constant, 'Z"A107"'],
+    ['a%b', f2003.Data_Ref, 'a % b'],
+    ['[ 1.2, 2.3e+2, -5.1e-3 ]', f2003.Array_Constructor,
+     '[1.2, 2.3E+2, - 5.1E-3]'],
+    ['PERSON  (12,  "Jones")', f2003.Part_Ref,
+     'PERSON(12, "Jones")'],
+    ['a', f2003.Name, 'a'],
+    ['(a)', f2003.Parenthesis, '(a)'],
+    ['(a +  b)', f2003.Parenthesis, '(a + b)'],
+]
+
+
+@pytest.mark.parametrize('source, expected_type, to_str', cases)
+def test_primary_subclasses(f2003_create, source, expected_type, to_str):
+    obj = f2003.Primary(source)
+    assert type(obj) == expected_type
+    assert str(obj) == to_str
+
+
+def test_no_match(f2003_create):
+    with pytest.raises(fparser.two.utils.NoMatchError):
+        obj = f2003.Primary('! A comment')

--- a/src/fparser/two/tests/fortran2003/test_primary_r701.py
+++ b/src/fparser/two/tests/fortran2003/test_primary_r701.py
@@ -34,38 +34,138 @@
 
 '''Test Fortran 2003 rule R701 : primary type.
 
+Sub-rules:
+    C701 (R701) The type-param-name shall be the name of a type parameter.
+    C702 (R701) The designator shall not be a whole assumed-size array
+
+Neither C701 nor C702 can be tested here, as they require context of the
+type defined outside of Primary.
+
 '''
+import sys
+
 import pytest
 
 import fparser.two.Fortran2003 as f2003
 import fparser.two.utils
 
 
-# A list of [Expression, Expected Type, ToString] for the test cases.
-SUBCLASS_CASES = [
-    ['1.2e-03', f2003.Real_Literal_Constant, '1.2E-03'],  # Constructor
+def assert_subclass_parse(source, base_type, actual_type=None,
+                          expected_str=None):
 
-    ['a%b', f2003.Data_Ref, 'a % b'],  # Designator
-    ['[ 1.2, 2.3e+2, -5.1e-3 ]', f2003.Array_Constructor,  # Array constructor
-     '[1.2, 2.3E+2, - 5.1E-3]'],
-    ['PERSON  (12,  "Jones")', f2003.Part_Ref,
-     'PERSON(12, "Jones")'],  # Structure constructor
-    ['a', f2003.Name, 'a'],  # Type param name
-    ['(a +  b)', f2003.Parenthesis, '(a + b)'], # Parenthesis (expr)
-]
-
-
-@pytest.mark.parametrize('source, expected_type, to_str', SUBCLASS_CASES)
-def test_primary_subclasses(f2003_create, source, expected_type, to_str):
-    '''
-    '''
     obj = f2003.Primary(source)
-    assert type(obj) == expected_type
-    assert str(obj) == to_str
+    assert type(obj) in possible_subclasses(base_type)
+
+    if actual_type:
+        assert isinstance(obj, actual_type)
+    else:
+        assert isinstance(obj, base_type)
+
+    if expected_str:
+        assert expected_str == str(obj)
+
+
+def test_Constant(f2003_create):
+    assert_subclass_parse(
+        '1.2e-03', f2003.Constant,
+        actual_type=f2003.Real_Literal_Constant,
+        expected_str='1.2E-03')
+
+
+def test_Designator(f2003_create):
+    assert_subclass_parse(
+        'array(1:5)', f2003.Designator,
+        actual_type=f2003.Array_Section,
+        expected_str='array(1 : 5)')
+
+
+def test_Array_Constructor(f2003_create):
+    assert_subclass_parse(
+        '[ 1.2, 2.3e + 2,    -5.1 e-3 ]', f2003.Array_Constructor,
+        actual_type=f2003.Array_Constructor,
+        expected_str='[1.2, 2.3E+2, - 5.1E-3]')
+
+
+def test_Structure_Constructor(f2003_create):
+    # The actual type is Part_Ref - it is possible that this could
+    # change in the future.
+    assert_subclass_parse(
+        'PERSON ( 12,   "Jones" )', f2003.Structure_Constructor,
+        actual_type=f2003.Part_Ref,
+        expected_str='PERSON(12, "Jones")')
+
+
+@pytest.mark.xfail(reason="Unable to reach Function_Reference when parsing")
+def test_Function_Reference(f2003_create):
+    '''This test demonstrates the inability to distinguish
+    Structure_Constructor from Function_Reference without more parse context
+    than is currently being provided.
+    '''
+    assert_subclass_parse(
+        'a_function(1.2, some_kwarg="hello")', f2003.Function_Reference)
+
+
+@pytest.mark.xfail
+def test_Type_Param_Inquiry():
+    '''This test demonstrates the inability to distinguish Designator from
+    Type_Param_Inquiry without more parse context than is currently being
+    provided.
+    '''
+    assert_subclass_parse(
+        'an_object % a_type_bound_function', f2003.Type_Param_Inquiry)
+
+
+@pytest.mark.xfail
+def test_Type_Param_Name():
+    '''This test demonstrates the inability to distinguish Constant from
+    Type_Param_Name without more parse context than is currently being
+    provided.
+    '''
+    assert_subclass_parse(
+        'A_TYPE', f2003.Type_Param_Name)
+
+
+def test_Parenthesis(f2003_create):
+    assert_subclass_parse(
+        '(a +  b)', f2003.Parenthesis,
+        expected_str='(a + b)')
+
+
+def possible_subclasses(node_type, _seen=None):
+    '''Given a type, return all of the subtypes that could
+    have been matched.
+    '''
+    seen = _seen or []
+    subclasses = getattr(node_type, 'subclass_names', [])
+    if node_type not in seen:
+        seen.append(node_type)
+
+    for subclass_name in subclasses:
+        module = sys.modules[node_type.__module__]
+        subclass = getattr(module, subclass_name, None)
+        if subclass is not None and subclass not in seen:
+            seen.append(subclass)
+            possible_subclasses(subclass, seen)
+    return seen
 
 
 def test_no_match(f2003_create):
-    '''
+    '''Test that a NoMatchError is raised if we provide code
+    that isn't allowed as a Primary type (e.g. a comment).
     '''
     with pytest.raises(fparser.two.utils.NoMatchError):
         obj = f2003.Primary('! A comment')
+
+
+@pytest.mark.xfail
+def test_C702_no_assumed_size_array(f2003_create):
+    '''Test C702 (R701) The designator shall not be a whole assumed-size array.
+    This test cannot be passed without more parse context of things like
+    defined types.
+    '''
+    source = """
+        integer(*)  :: assumed_size_array, result
+        result = assumed_size_array
+    """
+    # TODO: Implement the actual parsing of this source.
+    assert source is None

--- a/src/fparser/two/tests/fortran2003/test_primary_r701.py
+++ b/src/fparser/two/tests/fortran2003/test_primary_r701.py
@@ -54,6 +54,15 @@ def assert_subclass_parse(source, base_type, actual_type=None,
                           expected_str=None):
     '''Assert that the given source matches the given ``base_type``
     and optionally the specific type that it should produce.
+
+    :param source: The Fortran source to be parsed.
+    :type source: str or :py:class:`FortranReaderBase`
+    :param base_type: the base type from which a match is expected to be found
+    :type base_type: :py:class:`fortran.two.Fortran2003.Base` subclass
+    :param actual_type: The actual type matched by the parser.
+    :type actual_type: :py:class:`fortran.two.Fortran2003.Base` subclass
+    :param str expected_str: The expected ``str(result)`` of the parsed result
+
     '''
     obj = f2003.Primary(source)
     # Note: Check that the type exists in the possible types, rather than
@@ -74,6 +83,17 @@ def assert_subclass_parse(source, base_type, actual_type=None,
 def possible_subclasses(node_type, _seen=None):
     '''Given a type (e.g. Fortran2003.Primary), return all of the
     subtypes that could have been matched after parsing.
+
+    NOTE: This is not a general implementation. It is useful for testing
+    in some limited situations. Please refer to the Base.__new__ for the
+    actual logic for identifying possible_subclasses.
+
+    :param node_type: The root node from which to find all subclasses. 
+    :type source: :py:class:`fortran.two.Fortran2003.Base` subclass
+    :param _seen: Private list of seen subclasses, designed to support \
+                  recursive calls to this function.
+    :type _seen: None or list
+
     '''
     seen = _seen or []
     subclasses = getattr(node_type, 'subclass_names', [])
@@ -171,7 +191,7 @@ def test_no_match(f2003_create):
     that isn't allowed as a Primary type (e.g. a comment).
     '''
     with pytest.raises(fparser.two.utils.NoMatchError):
-        obj = f2003.Primary('! A comment')
+        _ = f2003.Primary('! A comment')
 
 
 @pytest.mark.xfail(reason="Requires more parse context (#190)")

--- a/src/fparser/two/tests/test_fortran2003.py
+++ b/src/fparser/two/tests/test_fortran2003.py
@@ -1750,62 +1750,6 @@ def test_deallocate_stmt():  # R635
 #
 
 
-def test_primary():  # R701
-
-    tcls = Primary
-    obj = tcls('a')
-    assert isinstance(obj, Name), repr(obj)
-    assert str(obj) == 'a'
-
-    obj = tcls('(a)')
-    assert isinstance(obj, Parenthesis), repr(obj)
-    assert str(obj) == '(a)'
-
-    obj = tcls('1')
-    assert isinstance(obj, Int_Literal_Constant), repr(obj)
-    assert str(obj) == '1'
-
-    obj = tcls('1.')
-    assert isinstance(obj, Real_Literal_Constant), repr(obj)
-    assert str(obj) == '1.'
-
-    obj = tcls('(1, n)')
-    assert isinstance(obj, Complex_Literal_Constant), repr(obj)
-    assert str(obj) == '(1, n)'
-
-    obj = tcls('.true.')
-    assert isinstance(obj, Logical_Literal_Constant), repr(obj)
-    assert str(obj) == '.TRUE.'
-
-    obj = tcls('"hey a()c"')
-    assert isinstance(obj, Char_Literal_Constant), repr(obj)
-    assert str(obj) == '"hey a()c"'
-
-    obj = tcls('b"0101"')
-    assert isinstance(obj, Binary_Constant), repr(obj)
-    assert str(obj) == 'B"0101"'
-
-    obj = tcls('o"0107"')
-    assert isinstance(obj, Octal_Constant), repr(obj)
-    assert str(obj) == 'O"0107"'
-
-    obj = tcls('z"a107"')
-    assert isinstance(obj, Hex_Constant), repr(obj)
-    assert str(obj) == 'Z"A107"'
-
-    obj = tcls('a % b')
-    assert isinstance(obj, Data_Ref), repr(obj)
-    assert str(obj) == 'a % b'
-
-    obj = tcls('a(:)')
-    assert isinstance(obj, Array_Section), repr(obj)
-    assert str(obj) == 'a(:)'
-
-    obj = tcls('0.0E-1')
-    assert isinstance(obj, Real_Literal_Constant), repr(obj)
-    assert str(obj) == '0.0E-1'
-
-
 def test_parenthesis():  # R701.h
 
     tcls = Parenthesis


### PR DESCRIPTION
Closes #167

The order defined by R701 wasn't honoured in ``subclass_names``, hence ``fparser.two`` was trying to recursively parse the contents of the brackets *before* it could figure out that it should try treating the expression as an array assignment.

Happy to add a test if desired. It would look like adding a large-ish source file with 400+ reals in an array. I figured that the order of the subclass_names shouldn't now change, so was 50/50 as to whether a test was really needed.