### PR TITLE
Remove automatic naming of End statements

### DIFF
--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -1318,7 +1318,6 @@ class Derived_Type_Def(BlockBase):  # R429
                                 Component_Part, Type_Bound_Procedure_Part],
                                End_Type_Stmt, reader,
                                match_names=True,
-                               set_unspecified_end_name=True  # C431
                                )
 
 

--- a/src/fparser/two/tests/fortran2003/test_main_program_r1101.py
+++ b/src/fparser/two/tests/fortran2003/test_main_program_r1101.py
@@ -58,9 +58,9 @@ def test_valid(f2003_create):
     # basic
     obj = Main_Program(get_reader("program a\nend"))
     assert isinstance(obj, Main_Program)
-    assert str(obj) == 'PROGRAM a\nEND PROGRAM a'
+    assert str(obj) == 'PROGRAM a\nEND'
     assert repr(obj) == ("Main_Program(Program_Stmt('PROGRAM', Name('a')), "
-                         "End_Program_Stmt('PROGRAM', None))")
+                         "End_Program_Stmt(None, None))")
 
     # name matching
     obj = Main_Program(get_reader("program a\nend program a"))
@@ -86,7 +86,7 @@ def test_valid(f2003_create):
     obj = Main_Program(get_reader("program a\ncontains\nsubroutine foo\n"
                                   "end\nend program a"))
     assert str(obj) == ("PROGRAM a\n  CONTAINS\n  SUBROUTINE foo\n"
-                        "  END SUBROUTINE foo\nEND PROGRAM a")
+                        "  END\nEND PROGRAM a")
 
     # specification-part + execution-part
     obj = Main_Program(get_reader("program a\ninteger i\ni=10\nend program a"))
@@ -96,13 +96,13 @@ def test_valid(f2003_create):
     obj = Main_Program(get_reader("program a\ni=10\ncontains\nsubroutine foo\n"
                                   "end\nend program a"))
     assert str(obj) == ("PROGRAM a\n  i = 10\n  CONTAINS\n  SUBROUTINE foo\n"
-                        "  END SUBROUTINE foo\nEND PROGRAM a")
+                        "  END\nEND PROGRAM a")
 
     # specification-part + execution-part + internal-subprogram-part
     obj = Main_Program(get_reader("program a\ninteger i\ni=10\ncontains\n"
                                   "subroutine foo\nend\nend program a"))
     assert str(obj) == ("PROGRAM a\n  INTEGER :: i\n  i = 10\n  CONTAINS\n  "
-                        "SUBROUTINE foo\n  END SUBROUTINE foo\nEND PROGRAM a")
+                        "SUBROUTINE foo\n  END\nEND PROGRAM a")
 
 
 def test_invalid1(f2003_create):

--- a/src/fparser/two/tests/fortran2003/test_program_r201.py
+++ b/src/fparser/two/tests/fortran2003/test_program_r201.py
@@ -216,7 +216,7 @@ def test_missing_prog(f2003_create):
       end
       ''')
     ast = Program(reader)
-    assert "END PROGRAM" in str(ast)
+    assert "END" in str(ast)
 
 
 @pytest.mark.xfail(reason="Only the main program is output")
@@ -266,7 +266,7 @@ def test_comment0(f2003_create):
         "end subroutine\n"), ignore_comments=False)
     ast = Program(reader)
     assert ("SUBROUTINE test\n"
-            "END SUBROUTINE test") in str(ast)
+            "END SUBROUTINE") in str(ast)
 
 
 def test_comment1(f2003_create):
@@ -295,7 +295,7 @@ def test_comment2(f2003_create):
     ast = Program(reader)
     assert ("! comment1\n"
             "SUBROUTINE test\n"
-            "END SUBROUTINE test\n"
+            "END SUBROUTINE\n"
             "! comment2") in str(ast)
 
 
@@ -313,9 +313,9 @@ def test_comment3(f2003_create):
       ''', ignore_comments=True)
     ast = Program(reader)
     assert ("SUBROUTINE test\n"
-            "END SUBROUTINE test\n"
+            "END SUBROUTINE\n"
             "MODULE example\n"
-            "END MODULE example") in str(ast)
+            "END MODULE") in str(ast)
     assert "! comment" not in str(ast)
 
 
@@ -334,10 +334,10 @@ def test_comment4(f2003_create):
     ast = Program(reader)
     assert ("! comment1\n"
             "SUBROUTINE test\n"
-            "END SUBROUTINE test\n"
+            "END SUBROUTINE\n"
             "! comment2\n"
             "MODULE example\n"
-            "END MODULE example\n"
+            "END MODULE\n"
             "! comment3") in str(ast)
 
 # Check includes are supported at this level
@@ -356,7 +356,7 @@ def test_include0(f2003_create):
     ast = Program(reader)
     assert ("INCLUDE '1'\n"
             "SUBROUTINE test\n"
-            "END SUBROUTINE test\n"
+            "END SUBROUTINE\n"
             "INCLUDE '2'") in str(ast)
 
 
@@ -376,10 +376,10 @@ def test_include1(f2003_create):
     ast = Program(reader)
     assert ("INCLUDE '1'\n"
             "SUBROUTINE test\n"
-            "END SUBROUTINE test\n"
+            "END SUBROUTINE\n"
             "INCLUDE '2'\n"
             "MODULE example\n"
-            "END MODULE example\n"
+            "END MODULE\n"
             "INCLUDE '3'") in str(ast)
     assert "! comment" not in str(ast)
 
@@ -412,13 +412,13 @@ def test_mix(f2003_create):
             "! comment1\n"
             "INCLUDE '2'\n"
             "SUBROUTINE test\n"
-            "END SUBROUTINE test\n"
+            "END SUBROUTINE\n"
             "INCLUDE '3'\n"
             "INCLUDE '4'\n"
             "! comment2\n"
             "! comment3\n"
             "MODULE example\n"
-            "END MODULE example\n"
+            "END MODULE\n"
             "! comment4\n"
             "INCLUDE '5'\n"
             "! comment5") in str(ast)

--- a/src/fparser/two/tests/fortran2008/test_end_submodule_stmt_r1119.py
+++ b/src/fparser/two/tests/fortran2008/test_end_submodule_stmt_r1119.py
@@ -45,7 +45,7 @@ from fparser.two.Fortran2008 import End_Submodule_Stmt
 def test_simple_1(f2008_create):
     '''Test the parsing of a minimal end-submodule statement.'''
     result = End_Submodule_Stmt("end")
-    assert str(result) == "END SUBMODULE"
+    assert str(result) == "END"
 
 
 def test_simple_2(f2008_create):

--- a/src/fparser/two/tests/fortran2008/test_program_unit_r202.py
+++ b/src/fparser/two/tests/fortran2008/test_program_unit_r202.py
@@ -66,7 +66,7 @@ def test_submodule(f2008_create):
       ''')
     ast = Program_Unit(reader)
     assert "SUBMODULE (foobar) bar\n" \
-        "END SUBMODULE bar" in str(ast)
+        "END" in str(ast)
 
 
 def test_submodule_nomatch(f2008_create):

--- a/src/fparser/two/tests/fortran2008/test_submodule_r1116.py
+++ b/src/fparser/two/tests/fortran2008/test_submodule_r1116.py
@@ -61,7 +61,7 @@ def test_submodule(f2008_create):
       ''')
     ast = Submodule(reader)
     assert "SUBMODULE (foobar) bar\n" \
-        "END SUBMODULE bar" in str(ast)
+        "END" in str(ast)
 
 
 def test_submodule_sp(f2008_create):
@@ -77,7 +77,7 @@ def test_submodule_sp(f2008_create):
     ast = Submodule(reader)
     assert "SUBMODULE (foobar) bar\n" \
         "  USE empty\n" \
-        "END SUBMODULE bar" in str(ast)
+        "END" in str(ast)
 
 
 def test_submodule_msp(f2008_create):
@@ -97,7 +97,7 @@ def test_submodule_msp(f2008_create):
         "  CONTAINS\n" \
         "  SUBROUTINE info\n" \
         "  END SUBROUTINE info\n" \
-        "END SUBMODULE bar" in str(ast)
+        "END" in str(ast)
 
 
 def test_submodule_both(f2008_create):
@@ -119,7 +119,7 @@ def test_submodule_both(f2008_create):
         "  CONTAINS\n" \
         "  SUBROUTINE info\n" \
         "  END SUBROUTINE info\n" \
-        "END SUBMODULE bar" in str(ast)
+        "END" in str(ast)
 
 # constraint C1112 format statement
 

--- a/src/fparser/two/tests/test_fortran2003.py
+++ b/src/fparser/two/tests/test_fortran2003.py
@@ -3410,7 +3410,7 @@ def test_main_program0():  # R1101 helper
 end
     '''))
     assert isinstance(obj0, Main_Program0), repr(obj0)
-    assert str(obj0) == 'END PROGRAM'
+    assert str(obj0) == 'END'
 
     obj0 = Main_Program0(get_reader('''\
 contains
@@ -3419,7 +3419,7 @@ contains
 end
     '''))
     assert isinstance(obj0, Main_Program0), repr(obj0)
-    assert str(obj0) == 'CONTAINS\nFUNCTION foo()\nEND FUNCTION\nEND PROGRAM'
+    assert str(obj0) == 'CONTAINS\nFUNCTION foo()\nEND\nEND'
 
 
 def test_module():  # R1104
@@ -3430,7 +3430,7 @@ module m
 end
     '''))
     assert isinstance(obj, tcls), repr(obj)
-    assert str(obj) == 'MODULE m\nEND MODULE m'
+    assert str(obj) == 'MODULE m\nEND'
 
     obj = tcls(get_reader('''\
 module m
@@ -3442,8 +3442,8 @@ end
     '''))
     assert isinstance(obj, tcls), repr(obj)
     assert (str(obj) ==
-            'MODULE m\n  TYPE :: a\n  END TYPE a\n  TYPE :: b\n  END TYPE b'
-            '\nEND MODULE m')
+            'MODULE m\n  TYPE :: a\n  END TYPE\n  TYPE :: b\n  END TYPE b'
+            '\nEND')
 
 
 def test_module_subprogram_part():  # R1107
@@ -3458,7 +3458,7 @@ contains
     ''', isfree=True))
     assert isinstance(obj, tcls), repr(obj)
     assert (str(obj) == 'CONTAINS\nSUBROUTINE foo(a)\n  REAL :: a'
-            '\n  a = 1.0\nEND SUBROUTINE foo')
+            '\n  a = 1.0\nEND')
 
 
 def test_module_nature():
@@ -3502,7 +3502,7 @@ real b
 end block data
     '''))
     assert isinstance(obj, tcls), repr(obj)
-    assert str(obj) == 'BLOCK DATA a\n  REAL :: b\nEND BLOCK DATA a'
+    assert str(obj) == 'BLOCK DATA a\n  REAL :: b\nEND BLOCK DATA'
 
 #
 # SECTION 12
@@ -3538,7 +3538,7 @@ def test_interface_specification():  # R1202
     end
     '''))
     assert isinstance(obj, Function_Body), repr(obj)
-    assert str(obj) == 'FUNCTION foo()\nEND FUNCTION'
+    assert str(obj) == 'FUNCTION foo()\nEND'
 
 
 def test_interface_stmt():  # R1203
@@ -3590,7 +3590,7 @@ end
 '''))
     assert isinstance(obj, Function_Body), repr(obj)
     assert (str(obj) ==
-            'FUNCTION foo(a) RESULT(c)\n  REAL :: a, c\nEND FUNCTION')
+            'FUNCTION foo(a) RESULT(c)\n  REAL :: a, c\nEND')
 
 
 def test_subroutine_body():
@@ -3964,7 +3964,7 @@ def test_end_function_stmt():  # R1230
     tcls = End_Function_Stmt
     obj = tcls('end')
     assert isinstance(obj, tcls), repr(obj)
-    assert str(obj) == 'END FUNCTION'
+    assert str(obj) == 'END'
 
     obj = tcls('endfunction')
     assert str(obj) == 'END FUNCTION'
@@ -4054,7 +4054,7 @@ def test_end_subroutine_stmt():  # R1234
 
     obj = tcls('end')
     assert isinstance(obj, tcls), repr(obj)
-    assert str(obj) == 'END SUBROUTINE'
+    assert str(obj) == 'END'
 
     obj = tcls('endsubroutine')
     assert isinstance(obj, tcls), repr(obj)

--- a/src/fparser/two/tests/test_parser.py
+++ b/src/fparser/two/tests/test_parser.py
@@ -64,7 +64,7 @@ def test_parserfactory_std():
     reader = FortranStringReader(fstring)
     ast = parser(reader)
     code = str(ast)
-    assert "SUBMODULE (x) y\nEND SUBMODULE y" in code
+    assert "SUBMODULE (x) y\nEND" in code
 
     # Repeat f2003 example to make sure that a previously valid (f2008)
     # match does not affect the current (f2003) invalid match.

--- a/src/fparser/two/utils.py
+++ b/src/fparser/two/utils.py
@@ -400,7 +400,6 @@ content : tuple
     def match(startcls, subclasses, endcls, reader,
               match_labels=False,
               match_names=False,
-              set_unspecified_end_name=False,
               match_name_classes=(),
               enable_do_label_construct_hook=False,
               enable_if_construct_hook=False,
@@ -421,7 +420,6 @@ content : tuple
         :type reader: str or instance of :py:class:`FortranReaderBase`
         :param bool match_labels: TBD
         :param bool match_names: TBD
-        :param bool set_unspecified_end_name: TBD
         :param tuple match_name_classes: TBD
         :param bool enable_do_label_construct_hook: TBD
         :param bool enable_if_construct_hook: TBD
@@ -524,10 +522,7 @@ content : tuple
                     start_name, end_name = content[start_idx].\
                                            get_start_name(), \
                                            content[-1].get_end_name()
-                    if set_unspecified_end_name and end_name is None and \
-                       start_name is not None:
-                        content[-1].set_name(start_name)
-                    elif end_name and not start_name:
+                    if end_name and not start_name:
                         raise FortranSyntaxError(
                             reader, "Name '{0}' has no corresponding starting "
                             "name".format(end_name))
@@ -1199,8 +1194,7 @@ class EndStmtBase(StmtBase):
             if stmt_name is None:
                 return
             return stmt_type, stmt_name(line)
-        else:
-            return stmt_type, None
+        return stmt_type, None
 
     def init(self, stmt_type, stmt_name):
         self.items = [stmt_type, stmt_name]

--- a/src/fparser/two/utils.py
+++ b/src/fparser/two/utils.py
@@ -598,8 +598,6 @@ content : tuple
                             'expected <%s-name> is %s but got %s. Ignoring.'
                             % (end_stmt.get_type().lower(),
                                start_stmt.get_name(), end_stmt.get_name()))
-                else:
-                    end_stmt.set_name(start_stmt.get_name())
         return content,
 
     def init(self, content):
@@ -1196,12 +1194,13 @@ class EndStmtBase(StmtBase):
         else:
             if require_stmt_type:
                 return
-            line = ''
+            return None, None
         if line:
             if stmt_name is None:
                 return
             return stmt_type, stmt_name(line)
-        return stmt_type, None
+        else:
+            return stmt_type, None
 
     def init(self, stmt_type, stmt_name):
         self.items = [stmt_type, stmt_name]
@@ -1214,21 +1213,12 @@ class EndStmtBase(StmtBase):
     def get_type(self):
         return self.items[0]
 
-    def set_name(self, name):
-        from fparser.two.Fortran2003 import Name
-        if self.items[1] is not None:
-            self.warning(
-                'item already has name %r, changing it to %r' %
-                (self.items[1], name))
-        if isinstance(name, Name):
-            self.items[1] = name
-        else:
-            self.items[1] = Name(name)
-
     def tostr(self):
         if self.items[1] is not None:
             return 'END %s %s' % tuple(self.items)
-        return 'END %s' % (self.items[0])
+        if self.items[0] is not None:
+            return 'END %s' % (self.items[0])
+        return 'END'
 
     def torepr(self):
         return '%s(%r, %r)' % (self.__class__.__name__, self.type, self.name)

--- a/src/fparser/two/utils.py
+++ b/src/fparser/two/utils.py
@@ -1198,7 +1198,6 @@ class EndStmtBase(StmtBase):
 
     def init(self, stmt_type, stmt_name):
         self.items = [stmt_type, stmt_name]
-        self.type, self.name = stmt_type, stmt_name
         return
 
     def get_name(self):
@@ -1215,7 +1214,8 @@ class EndStmtBase(StmtBase):
         return 'END'
 
     def torepr(self):
-        return '%s(%r, %r)' % (self.__class__.__name__, self.type, self.name)
+        return '%s(%r, %r)' % (
+            self.__class__.__name__, self.get_type(), self.get_name())
 
     def get_end_name(self):
         name = self.items[1]


### PR DESCRIPTION
Currently ``fparser.two`` automatically names end statements based on their counterpart "start" statements.
It also automatically injects statement type information into the parsed End statement object. This essentially means that we are preventing a round-trip of the original code, and even though it is desirable to have as much context as possible in the outputted source, it is problematic to achieve correctly and questionable as to whether it should be done *at parse time*. This was discussed in https://github.com/stfc/fparser/pull/186#issuecomment-477638184. I propose that similar automatic-naming functionality be restored as an (optional) *post-processing* step on the parse-tree, rather than a parse-time manipulation (though not in this PR).