### PR TITLE
Changes needed to get the tests passing with python3.6 on an ASCII terminal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Modifications by (in alphabetical order):
 * A. R. Porter, Science & Technology Facilities Council, UK
 * P. Vitt, University of Siegen, Germany
 
+14/06/2019 PR #194. Fix for unicode input errors in Python 3.6.
+
 05/04/2019 PR #192. END statements which use class EndStmtBase now output
 	   the same tokens as the input e.g. names are not added if they
 	   don't exist in the input.

--- a/src/fparser/common/sourceinfo.py
+++ b/src/fparser/common/sourceinfo.py
@@ -69,6 +69,7 @@ fixed format. It also tries to differentiate between strict and "pyf" although
 I'm not sure what that is.
 '''
 
+import io
 import os
 import re
 import six
@@ -315,7 +316,7 @@ def get_source_info(file_candidate):
         #
         from fparser.common.utils import make_clean_tmpfile
         tmpfile = make_clean_tmpfile(file_candidate)
-        with open(tmpfile, 'r') as file_object:
+        with io.open(tmpfile, 'r', encoding='utf8') as file_object:
             string = get_source_info_str(file_object.read())
         os.remove(tmpfile)
         return string

--- a/src/fparser/common/tests/test_sourceinfo.py
+++ b/src/fparser/common/tests/test_sourceinfo.py
@@ -362,7 +362,7 @@ def test_get_source_info_utf8():
     encoding = dict(encoding='UTF-8') if six.PY3 else {}
     with tempfile.NamedTemporaryFile(mode='w', **encoding) as tmp_file:
         content = u'''
-            ! A fortran comment with a unicode character "{}"
+            ! A fortran comment with a unicode character "{0}"
         '''.format(u"\u2014")
         if six.PY2:
             content = content.encode('UTF-8')

--- a/src/fparser/common/tests/test_sourceinfo.py
+++ b/src/fparser/common/tests/test_sourceinfo.py
@@ -354,15 +354,14 @@ def test_get_source_info_file(extension, header, content):
 
 
 def test_get_source_info_utf8():
-    kwargs = dict(encoding='utf8') if six.PY3 else {}
-    with tempfile.NamedTemporaryFile(mode='w', **kwargs) as tmp_file:
+    encoding = dict(encoding='UTF-8') if six.PY3 else {}
+    with tempfile.NamedTemporaryFile(mode='w', **encoding) as tmp_file:
         content = u'''
             ! A fortran comment with a unicode character "{}"
         '''.format(u"\u2014")
-        if six.PY3:
-            tmp_file.write(content)
-        else:
-            tmp_file.write(content.encode('utf8'))
+        if six.PY2:
+            content = content.encode('UTF-8')
+        tmp_file.write(content)
         tmp_file.flush()
 
         source_info = get_source_info(tmp_file.name)

--- a/src/fparser/common/tests/test_sourceinfo.py
+++ b/src/fparser/common/tests/test_sourceinfo.py
@@ -354,6 +354,11 @@ def test_get_source_info_file(extension, header, content):
 
 
 def test_get_source_info_utf8():
+    '''
+    Tests that Fortran code containing a unicode character can be read
+    by the get_source_info method.
+
+    '''
     encoding = dict(encoding='UTF-8') if six.PY3 else {}
     with tempfile.NamedTemporaryFile(mode='w', **encoding) as tmp_file:
         content = u'''

--- a/src/fparser/common/tests/test_sourceinfo.py
+++ b/src/fparser/common/tests/test_sourceinfo.py
@@ -44,6 +44,7 @@ from __future__ import print_function
 import os
 import tempfile
 import pytest
+import six
 
 from fparser.common.sourceinfo import FortranFormat, \
                                       get_source_info_str, get_source_info
@@ -350,6 +351,22 @@ def test_get_source_info_file(extension, header, content):
             assert source_info == header[1]
         else:  # No header
             assert source_info == content[1]
+
+
+def test_get_source_info_utf8():
+    kwargs = dict(encoding='utf8') if six.PY3 else {}
+    with tempfile.NamedTemporaryFile(mode='w', **kwargs) as tmp_file:
+        content = u'''
+            ! A fortran comment with a unicode character "{}"
+        '''.format(u"\u2014")
+        if six.PY3:
+            tmp_file.write(content)
+        else:
+            tmp_file.write(content.encode('utf8'))
+        tmp_file.flush()
+
+        source_info = get_source_info(tmp_file.name)
+    assert source_info is not None
 
 
 ##############################################################################

--- a/src/fparser/common/tests/test_utils.py
+++ b/src/fparser/common/tests/test_utils.py
@@ -38,7 +38,10 @@ Test the various utility functions
 """
 import io
 import os
+
 import pytest
+import six
+
 from fparser.common.utils import split_comma, ParseError, make_clean_tmpfile
 from fparser.two.utils import InternalError
 
@@ -142,7 +145,9 @@ def create_tmp_file(string, tmpdir, filename="tmp_in.f90"):
     '''
     filepath = os.path.join(str(tmpdir), filename)
     # Create the input_file
-    tmp_file = io.open(filepath, "w", encoding='utf8')
+    tmp_file = io.open(filepath, "w", encoding='UTF-8')
+    if six.PY2:
+        string = unicode(string)
     tmp_file.write(string)
     return tmp_file.name
 
@@ -201,7 +206,7 @@ def test_mct_parse_error(tmpdir):
     False.
 
     '''
-    invalid_content = "\xca"
+    invalid_content = u"\xca"
     input_filepath = create_tmp_file(invalid_content, tmpdir)
     with pytest.raises(ParseError) as excinfo:
         _ = make_clean_tmpfile(input_filepath, skip_bad_input=False,
@@ -218,8 +223,8 @@ def test_mct_skip_error(tmpdir, caplog):
     default and that logging messages are created.
 
     '''
-    content = ("HELLO")
-    invalid_content = "\xca".join(content)
+    content = "HELLO"
+    invalid_content = u"\xca".join(content)
     input_filepath = create_tmp_file(invalid_content, tmpdir)
     output_filepath = make_clean_tmpfile(input_filepath, encoding="ascii")
     with open(output_filepath, "r") as cfile:

--- a/src/fparser/common/tests/test_utils.py
+++ b/src/fparser/common/tests/test_utils.py
@@ -36,6 +36,7 @@
 Test the various utility functions
 
 """
+import io
 import os
 import pytest
 from fparser.common.utils import split_comma, ParseError, make_clean_tmpfile
@@ -141,7 +142,7 @@ def create_tmp_file(string, tmpdir, filename="tmp_in.f90"):
     '''
     filepath = os.path.join(str(tmpdir), filename)
     # Create the input_file
-    tmp_file = open(filepath, "w")
+    tmp_file = io.open(filepath, "w", encoding='utf8')
     tmp_file.write(string)
     return tmp_file.name
 

--- a/src/fparser/common/utils.py
+++ b/src/fparser/common/utils.py
@@ -333,6 +333,7 @@ class meta_classes(type):
             raise AttributeError('instance does not have attribute %r' % (name))
         return cls
 
+
 class classes(six.with_metaclass(meta_classes, type)):
     """Make classes available as attributes of this class.
 

--- a/src/fparser/common/utils.py
+++ b/src/fparser/common/utils.py
@@ -86,9 +86,8 @@ import logging
 import re
 import os
 import glob
-import sys
 import traceback
-from six import with_metaclass
+import six
 
 class ParseError(Exception):
     pass
@@ -331,7 +330,7 @@ class meta_classes(type):
             raise AttributeError('instance does not have attribute %r' % (name))
         return cls
 
-class classes(with_metaclass(meta_classes, type)):
+class classes(six.with_metaclass(meta_classes, type)):
     """Make classes available as attributes of this class.
 
     To add a class to the attributes list, one must use::
@@ -408,9 +407,12 @@ def make_clean_tmpfile(filename, skip_bad_input=True, encoding="utf8"):
                             errors='ignore')
 
     # Set delete to False so file will not be deleted when closed.
-    temp_file = tempfile.NamedTemporaryFile(mode="w", delete=False)
+    tempfile_kwargs = dict(mode='w', delete=False)
+    if six.PY3:
+        tempfile_kwargs['encoding'] = 'utf8'
+    temp_file = tempfile.NamedTemporaryFile(**tempfile_kwargs)
     input = orig_file.read()
-    if sys.version_info.major < 3:
+    if six.PY2:
         # Python 2. Unicode needs to be encoded.
         temp_file.write(input.encode("UTF-8"))
     else:


### PR DESCRIPTION
As mentioned earlier in today's telco, under certain conditions (py>2,<py3.7, non-unicode terminal) the *existing* tests do not pass.

```
pytest common/tests/test_utils.py
================================================================ test session starts =================================================================
platform linux -- Python 3.5.6, pytest-4.3.0, py-1.8.0, pluggy-0.9.0
rootdir: /data/local/itpe/fparser, inifile:
plugins: xdist-1.26.1, forked-1.0.2
collected 12 items                                                                                                                                   

common/tests/test_utils.py .........FFF                                                                                                        [100%]

====================================================================== FAILURES ======================================================================
________________________________________________________________ test_mct_parse_error ________________________________________________________________

tmpdir = local('/var/tmp/pytest-of-itpe/pytest-134/test_mct_parse_error0')

    def test_mct_parse_error(tmpdir):
        '''Test that an appropriate exception is raised if there is an invalid
        character in the input file and skip_bad_argument is set to
        False.
    
        '''
        invalid_content = "\xca"
>       input_filepath = create_tmp_file(invalid_content, tmpdir)

common/tests/test_utils.py:204: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

string = '\xca', tmpdir = local('/var/tmp/pytest-of-itpe/pytest-134/test_mct_parse_error0'), filename = 'tmp_in.f90'

    def create_tmp_file(string, tmpdir, filename="tmp_in.f90"):
        '''Utility function used by make_clean_tmpfile tests. Creates a
        temporary file and adds the content of a text string to it.
    
        :param str string: string containing content to be placed in a \
        file.
        :param tmpdir: pytest temporary directory structure.
        :type tmpdir: :py:class:'py._path.local.LocalPath'
        :param str filename: the name of the temporary file
    
        :returns: the filepath of the created file
        :rtype: str
    
        '''
        filepath = os.path.join(str(tmpdir), filename)
        # Create the input_file
        tmp_file = open(filepath, "w")
>       tmp_file.write(string)
E       UnicodeEncodeError: 'ascii' codec can't encode character '\xca' in position 0: ordinal not in range(128)

common/tests/test_utils.py:145: UnicodeEncodeError
________________________________________________________________ test_mct_skip_error _________________________________________________________________

tmpdir = local('/var/tmp/pytest-of-itpe/pytest-134/test_mct_skip_error0'), caplog = <_pytest.logging.LogCaptureFixture object at 0x7fa5483dc5f8>

    def test_mct_skip_error(tmpdir, caplog):
        '''Test that invalid characters are skipped in an input file by
        default and that logging messages are created.
    
        '''
        content = ("HELLO")
        invalid_content = "\xca".join(content)
>       input_filepath = create_tmp_file(invalid_content, tmpdir)

common/tests/test_utils.py:222: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

string = 'H\xcaE\xcaL\xcaL\xcaO', tmpdir = local('/var/tmp/pytest-of-itpe/pytest-134/test_mct_skip_error0'), filename = 'tmp_in.f90'

    def create_tmp_file(string, tmpdir, filename="tmp_in.f90"):
        '''Utility function used by make_clean_tmpfile tests. Creates a
        temporary file and adds the content of a text string to it.
    
        :param str string: string containing content to be placed in a \
        file.
        :param tmpdir: pytest temporary directory structure.
        :type tmpdir: :py:class:'py._path.local.LocalPath'
        :param str filename: the name of the temporary file
    
        :returns: the filepath of the created file
        :rtype: str
    
        '''
        filepath = os.path.join(str(tmpdir), filename)
        # Create the input_file
        tmp_file = open(filepath, "w")
>       tmp_file.write(string)
E       UnicodeEncodeError: 'ascii' codec can't encode character '\xca' in position 1: ordinal not in range(128)

common/tests/test_utils.py:145: UnicodeEncodeError
___________________________________________________________________ test_mct_utf8 ____________________________________________________________________

    def test_mct_utf8():
        '''Test that utf8 content can be read and written correctly in
        make_clean_tmpfile.
    
        '''
        filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                "utf.f90")
>       _ = make_clean_tmpfile(filepath)

common/tests/test_utils.py:243: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
common/utils.py:418: in make_clean_tmpfile
    temp_file.write(input)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

args = ('! -----------------------------------------------------------------------------\\n! BSD 3-Clause License\\n!\\n! Copyri...------------------------------------\\n! Author R. W. Ford STFC Daresbury Lab\\nprogram utf\\n! N\xb2<0\\nend program utf\\n',)
kwargs = {}

    @_functools.wraps(func)
    def func_wrapper(*args, **kwargs):
>       return func(*args, **kwargs)
E       UnicodeEncodeError: 'ascii' codec can't encode character '\xb2' in position 1811: ordinal not in range(128)

../../env_35/lib/python3.5/tempfile.py:483: UnicodeEncodeError
========================================================= 3 failed, 9 passed in 0.27 seconds =========================================================

```

This PR fixes the *existing* tests to function under the conditions described above, and fixes a further case which is triggered by psyclone on LFRic's ``held_suarez_fv_kernel`` (```psyclone working/unit-tests/algorithm/slow_physics_alg_mod.x90 -d ../../gungho/source/kernel/```). A related but distinct issue was fixed in https://github.com/stfc/PSyclone/pull/349 - these are additive changes - both are needed to progress psyclone use with Python 3.6 (our current production version).

To get the tests to fail on my development Mac, I created a Python 3.5 environment and ran the tests with ``LANG=ascii pytest src/fparser``. This produced the same errors being seen on our scientific desktops.