### PR TITLE
WIP: Enable a limited terminal in the Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ before_install:
 install:
   - "pip install ."
 script:
+  # fparser should work even under limited terminal conditions
+  # (this is only relevant for versions before Python 3.7).
+  - export LANG=ascii
   - coverage run --source=fparser -m py.test
   - coverage report -m
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
 script:
   # fparser should work even under limited terminal conditions
   # (this is only relevant for versions before Python 3.7).
-  - export LANG=ascii
+  - export LC_ALL=POSIX
   - coverage run --source=fparser -m py.test
   - coverage report -m
 after_success:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ Modifications by (in alphabetical order):
 * A. R. Porter, Science & Technology Facilities Council, UK
 * P. Vitt, University of Siegen, Germany
 
-14/06/2019 PR #181. Added an xfailing test to demonstrate an error in EndStmtBase.
+15/06/2019 PR #195. Travis change to make it raise errors with failing
+	   unicode tests.
+
+14/06/2019 PR #181. Added an xfailing test to demonstrate an error in
+	   EndStmtBase.
 
 14/06/2019 PR #196. Fix for unicode input errors in Python.
 
@@ -20,7 +24,7 @@ Modifications by (in alphabetical order):
 
 05/04/2019 PR #192. END statements which use class EndStmtBase now output
 	   the same tokens as the input e.g. names are not added if they
-	do	n't exist in the input.
+	   don't exist in the input.
 
 29/03/2019 Issue #167 and PR #182. Fix to Fortran2003 rule 701 where large
            codes were causing recurse-depth errors in Python.


### PR DESCRIPTION
If we can get this working, then a rich unicode terminal will be just fine.

Hopefully, this will demonstrate the tests that are currently failing on master with ``LANG=ascii``.

Once #194 is merged, I will rebase this and the CI should go green. :tada: 