### PR TITLE
Fix unicode handling of FortranFileReader, as used by PSyclone.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Modifications by (in alphabetical order):
 * A. R. Porter, Science & Technology Facilities Council, UK
 * P. Vitt, University of Siegen, Germany
 
+14/06/2019 PR #196. Fix for unicode input errors in Python.
+
 14/06/2019 PR #194. Fix for unicode input errors in Python 3.6.
 
 05/04/2019 PR #192. END statements which use class EndStmtBase now output

--- a/src/fparser/common/readfortran.py
+++ b/src/fparser/common/readfortran.py
@@ -67,7 +67,8 @@
 #
 # Author: Pearu Peterson <pearu@cens.ioc.ee>
 # Created: May 2006
-# Modified by R. W. Ford STFC Daresbury Lab
+# Modified by R. W. Ford, STFC Daresbury Lab
+# Modified by P. Elson, Met Office
 
 """Provides Fortran reader classes.
 
@@ -649,6 +650,8 @@ class FortranReaderBase(object):
             try:
                 line = line.encode('ascii', errors='strict')
             except UnicodeEncodeError:
+                # Can't cast to str as there are non-ascii characters
+                # in the line.
                 pass
 
         self.source_lines.append(line)

--- a/src/fparser/common/tests/test_readfortran.py
+++ b/src/fparser/common/tests/test_readfortran.py
@@ -42,9 +42,13 @@ Test battery associated with fparser.common.readfortran package.
 '''
 from __future__ import print_function
 
+import io
 import os.path
 import tempfile
+
 import pytest
+import six
+
 from fparser.common.readfortran import FortranFileReader, FortranStringReader
 import fparser.common.sourceinfo
 import fparser.common.tests.logging_utils
@@ -594,7 +598,10 @@ def test_multi_put_item(ignore_comments):
 
 ##############################################################################
 
-FULL_FREE_SOURCE = '''
+FULL_FREE_SOURCE = u'''
+
+!> Unicode comment: ❤ ✓ ☂ ♞ ☯
+
 program test
 
   implicit none
@@ -604,7 +611,8 @@ program test
 end program test
 '''
 
-FULL_FREE_EXPECTED = ['program test',
+FULL_FREE_EXPECTED = [u'!> Unicode comment: ❤ ✓ ☂ ♞ ☯',
+                      'program test',
                       '  implicit none',
                       "  character, paramater :: nature = 'free format'",
                       'end program test']
@@ -619,8 +627,8 @@ def test_filename_reader():
     handle, filename = tempfile.mkstemp(suffix='.f90', text=True)
     os.close(handle)
     try:
-        with open(filename, mode='w') as source_file:
-            print(FULL_FREE_SOURCE, file=source_file)
+        with io.open(filename, mode='w', encoding='UTF-8') as source_file:
+            source_file.write(FULL_FREE_SOURCE)
 
         unit_under_test = FortranFileReader(filename)
         expected = fparser.common.sourceinfo.FortranFormat(True, False)
@@ -642,10 +650,10 @@ def test_file_reader():
     handle, filename = tempfile.mkstemp(suffix='.f90', text=True)
     os.close(handle)
     try:
-        with open(filename, mode='w') as source_file:
-            print(FULL_FREE_SOURCE, file=source_file)
+        with io.open(filename, mode='w', encoding='UTF-8') as source_file:
+            source_file.write(FULL_FREE_SOURCE)
 
-        with open(filename, mode='r') as source_file:
+        with io.open(filename, mode='r', encoding='UTF-8') as source_file:
             unit_under_test = FortranFileReader(source_file)
 
             expected = fparser.common.sourceinfo.FortranFormat(True, False)

--- a/src/fparser/common/tests/test_readfortran.py
+++ b/src/fparser/common/tests/test_readfortran.py
@@ -34,7 +34,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ##############################################################################
-# Modified M.Hambley, UK Met Office
+# Modified M. Hambley and P. Elson, Met Office
 # Modified R. W. Ford, STFC Daresbury Lab
 ##############################################################################
 '''
@@ -47,7 +47,6 @@ import os.path
 import tempfile
 
 import pytest
-import six
 
 from fparser.common.readfortran import FortranFileReader, FortranStringReader
 import fparser.common.sourceinfo
@@ -606,7 +605,7 @@ program test
 
   implicit none
 
-  character, paramater :: nature = 'free format'
+  character, parameter :: nature = 'free format'
 
 end program test
 '''
@@ -614,7 +613,7 @@ end program test
 FULL_FREE_EXPECTED = [u'!> Unicode comment: ❤ ✓ ☂ ♞ ☯',
                       'program test',
                       '  implicit none',
-                      "  character, paramater :: nature = 'free format'",
+                      "  character, parameter :: nature = 'free format'",
                       'end program test']
 
 


### PR DESCRIPTION
I believe this is the final change needed in fparser to handle unicode comments from ASCII terminals, as was being seen when running ``psyclone ${LFRIC}/miniapps/skeleton/working/unit-tests/algorithm/slow_physics_alg_mod.x90 -d ${LFRIC}/gungho/source/kernel/``. That particular invocation of psyclone was resulting in the kernel not being found once the unicode handling had been fixed by #194: 

```
Error, unexpected exception, please report to the authors:
Description ...
list index out of range
Type ...
<class 'IndexError'>
Stacktrace ...
  File "/data/local/itpe/PSyclone/src/psyclone/generator.py", line 396, in main
    kern_naming=args.kernel_renaming)
  File "/data/local/itpe/PSyclone/src/psyclone/generator.py", line 222, in generate
    line_length=line_length)
  File "/data/local/itpe/PSyclone/src/psyclone/parse/algorithm.py", line 102, in parse
    return my_parser.parse(alg_filename)
  File "/data/local/itpe/PSyclone/src/psyclone/parse/algorithm.py", line 220, in parse
    invoke_call = self.create_invoke_call(statement)
  File "/data/local/itpe/PSyclone/src/psyclone/parse/algorithm.py", line 268, in create_invoke_call
    kernel_call = self.create_kernel_call(argument)
  File "/data/local/itpe/PSyclone/src/psyclone/parse/algorithm.py", line 305, in create_kernel_call
    kernel_name, args)
  File "/data/local/itpe/PSyclone/src/psyclone/parse/algorithm.py", line 378, in create_coded_kernel_call
    modast, name=kernel_name), args)
  File "/data/local/itpe/PSyclone/src/psyclone/parse/kernel.py", line 240, in create
    return DynKernMetadata(parse_tree, name=name)
  File "/data/local/itpe/PSyclone/src/psyclone/dynamo0p3.py", line 838, in __init__
    KernelType.__init__(self, ast, name=name)
  File "/data/local/itpe/PSyclone/src/psyclone/parse/kernel.py", line 667, in __init__
    self._ktype = get_kernel_metadata(name, ast)
  File "/data/local/itpe/PSyclone/src/psyclone/parse/kernel.py", line 604, in get_kernel_metadata
    for statement, _ in fpapi.walk(ast, -1):
  File "/data/local/itpe/fparser/src/fparser/api.py", line 251, in walk
    last_stmt = stmt.content[-1]
```

Ultimately this was because of a failure mode of ``fparser.api`` producing an empty source:

```
>>> import fparser.api as fpapi
>>> fname = 'source/kernel/held_suarez_fv_kernel_mod.F90'
>>> fpapi.parse(fname)
!BEGINSOURCE <_io.TextIOWrapper name='/var/tmp/tmpcp7g3fl2' mode='r' encoding='ANSI_X3.4-1968'> mode=free
```