### PR TITLE
install fparser2 script entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,11 @@ if __name__ == '__main__':
         packages=PACKAGES,
         package_dir={"": "src"},
         install_requires=['six'],
+        entry_points={
+            'console_scripts': [
+                'fparser2=fparser.scripts.fparser2:main',
+            ],
+        },
         # We need the following line to ensure we get the fparser/log.config
         # file installed.
         include_package_data=True)


### PR DESCRIPTION
Console script entry point for `fparser2.py` will be installed, such that user can invoke the script with simply:

```bash
fparser2 program.f90
```

This is especially useful if the user has installed fparser from pypi and might not know where the script is installed.