### PR TITLE
Changed number of expected arguments for intrinsic function IBITS to 3

### DIFF
--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -9539,7 +9539,7 @@ class Intrinsic_Name(STRINGBase):  # No explicit rule
         "BTEST": {"min": 2, "max": 2},
         "IAND": {"min": 2, "max": 2},
         "IBCLR": {"min": 2, "max": 2},
-        "IBITS": {"min": 2, "max": 2},
+        "IBITS": {"min": 3, "max": 3},
         "IBSET": {"min": 2, "max": 2},
         "IEOR": {"min": 2, "max": 2},
         "IOR": {"min": 2, "max": 2},


### PR DESCRIPTION
Intrinsic function `IBITS(I, POS, LEN)` should expect exactly 3 arguments, fparser required it to have exactly 2.

Reference: https://j3-fortran.org/doc/year/04/04-007.pdf#page=312
Page 312, Line 24