### PR TITLE
Add detection and dedicated type for Cpp directives to readfortran

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Modifications by (in alphabetical order):
 * J. Tiira, University of Helsinki, Finland
 * P. Vitt, University of Siegen, Germany
 
+07/03/2020 PR #250 for #248. Identify CPP directives in the reader.
+
 14/02/2020 PR #246 for #245. Fixes some deprecation warnings about '\'
            characters in strings.
 

--- a/src/fparser/common/readfortran.py
+++ b/src/fparser/common/readfortran.py
@@ -518,13 +518,13 @@ class SyntaxErrorMultiLine(MultiLine, FortranReaderError):
 class CppDirective(Line):
     '''Holds a preprocessor directive source line.
 
-    :param str line: String containing the text of a single or \
-    multi-line preprocessor directive
-    :param linenospan: A 2-tuple containing the start and end line \
-    numbers of the directive from the input source.
+    :param str line: string containing the text of a single or \
+                     multi-line preprocessor directive.
+    :param linenospan: a 2-tuple containing the start and end line \
+                       numbers of the directive from the input source.
     :type linenospan: (int, int)
     :param reader: The reader object being used to read the input \
-    source.
+                   source.
     :type reader: :py:class:`fparser.common.readfortran.FortranReaderBase`
 
     '''
@@ -974,15 +974,17 @@ class FortranReaderBase(object):
         return Comment(comment, (startlineno, endlineno), self)
 
     def cpp_directive_item(self, line, startlineno, endlineno):
-        """ Construct :py:class:`CppDirective` item.
+        '''
+        Construct :py:class:`fparser.common.readfortran.CppDirective` item.
 
-        :param str line: String containing the text of a single or \
-        multi-line preprocessor directive
-        :param int startlineno: Start line number of the directive from \
-        the input source.
-        :param int endlineno: End line number of the directive from \
-        the input source.
-        """
+        :param str line: string containing the text of a single or \
+                         multi-line preprocessor directive.
+        :param int startlineno: start line number of the directive from \
+                                the input source.
+        :param int endlineno: end line number of the directive from \
+                              the input source.
+
+        '''
         return CppDirective(line, (startlineno, endlineno), self)
 
     # For handling messages:
@@ -1078,23 +1080,25 @@ class FortranReaderBase(object):
     # Auxiliary methods for processing raw source lines:
 
     def handle_cpp_directive(self, line):
-        """Determine whether the current line is likely to hold
+        '''
+        Determine whether the current line is likely to hold
         C preprocessor directive.
 
-        If the first character of a line is the symbol ``#`` it is assumed
-        this is a preprocessor directive. This means any whitespace in
-        front of the directive are not recognized.
+        If the first non whitespace character of a line is the symbol ``#``
+        it is assumed this is a preprocessor directive.
 
-        Preprocessor directives can be used only in Fortran codes.  They are
+        Preprocessor directives can be used only in Fortran codes. They are
         ignored when used inside PYF files.
 
         The actual line content is not altered.
 
         :param str line: the line to be tested for directives.
-        :return: A tuple containing the line and True/False depending on \
-            whether it holds a C preprocessor directive.
+
+        :return: a tuple containing the line and True/False depending on \
+                 whether it holds a C preprocessor directive.
         :rtype: (str, bool)
-        """
+
+        '''
         if not line or self._format.is_pyf:
             return (line, False)
         return (line, line.lstrip().startswith('#'))
@@ -1283,13 +1287,6 @@ class FortranReaderBase(object):
             return
         startlineno = self.linecount
         line, is_cpp_directive = self.handle_cpp_directive(line)
-        line = self.handle_cf2py_start(line)
-        is_f2py_directive = startlineno in self.f2py_comment_lines
-        isstrict = self._format.is_strict
-        have_comment = False
-        label = None
-        name = None
-
         if is_cpp_directive:
             # CPP directive line
             lines = []
@@ -1301,6 +1298,13 @@ class FortranReaderBase(object):
             endlineno = self.linecount
             return self.cpp_directive_item(''.join(lines), startlineno,
                                            endlineno)
+
+        line = self.handle_cf2py_start(line)
+        is_f2py_directive = startlineno in self.f2py_comment_lines
+        isstrict = self._format.is_strict
+        have_comment = False
+        label = None
+        name = None
 
         if self._format.is_pyf:
             # handle multilines
@@ -1495,8 +1499,8 @@ class FortranReaderBase(object):
                     label, line = extract_label(line)
                     name, line = extract_construct_name(line)
 
-                line, qc, had_comment \
-                    = handle_inline_comment(line, self.linecount, qc)
+                line, qc, had_comment = \
+                    handle_inline_comment(line, self.linecount, qc)
                 have_comment |= had_comment
                 is_f2py_directive = self.linecount in self.f2py_comment_lines
 

--- a/src/fparser/common/readfortran.py
+++ b/src/fparser/common/readfortran.py
@@ -518,9 +518,16 @@ class SyntaxErrorMultiLine(MultiLine, FortranReaderError):
 class CppDirective(Line):
     '''Holds a preprocessor directive source line.
 
-    Attributes are the same as for :py:class:`Line`.
-    '''
+    :param str line: String containing the text of a single or \
+    multi-line preprocessor directive
+    :param linenospan: A 2-tuple containing the start and end line \
+    numbers of the directive from the input source.
+    :type linenospan: (int, int)
+    :param reader: The reader object being used to read the input \
+    source.
+    :type reader: :py:class:`fparser.common.readfortran.FortranReaderBase`
 
+    '''
     def __init__(self, line, linenospan, reader):
         super(CppDirective, self).__init__(
             line, linenospan, None, None, reader)
@@ -966,8 +973,15 @@ class FortranReaderBase(object):
         """
         return Comment(comment, (startlineno, endlineno), self)
 
-    def cpp_directive_item(self, line, startlineno, endlineno,):
-        """ Construct CppDirective item.
+    def cpp_directive_item(self, line, startlineno, endlineno):
+        """ Construct :py:class:`CppDirective` item.
+
+        :param str line: String containing the text of a single or \
+        multi-line preprocessor directive
+        :param int startlineno: Start line number of the directive from \
+        the input source.
+        :param int endlineno: End line number of the directive from \
+        the input source.
         """
         return CppDirective(line, (startlineno, endlineno), self)
 
@@ -1285,7 +1299,8 @@ class FortranReaderBase(object):
                 line = get_single_line()
             lines.append(line)
             endlineno = self.linecount
-            return self.cpp_directive_item(''.join(lines), startlineno, endlineno)
+            return self.cpp_directive_item(''.join(lines), startlineno,
+                                           endlineno)
 
         if self._format.is_pyf:
             # handle multilines

--- a/src/fparser/common/tests/test_readfortran.py
+++ b/src/fparser/common/tests/test_readfortran.py
@@ -990,18 +990,21 @@ def test_extract_construct_name():
     assert text_result == "stuff"
 
 
-def test_handle_cpp_directive():
+@pytest.mark.parametrize('input_text, ref', [
+    ('#include "abc"', True),
+    (' #include "abc"', False),
+    ('#define ABC 1', True),
+    ('#ifdef ABC', True),
+    ('#if !defined(ABC)', True),
+    ('abc #define', False),
+    ('"#"', False),
+    ('! #', False)])
+def test_handle_cpp_directive(input_text, ref):
     '''Test the function that detects cpp directives in readfortran.py.'''
-    test_data = {
-            '#include "abc"': True, ' #include "abc"': False,
-            '#define ABC 1': True, '#ifdef ABC': True,
-            '#if !defined(ABC)': True, 'abc #define': False,
-            '"#"': False, '! #': False}
-    for input_text, ref in test_data.items():
-        reader = FortranStringReader(input_text)
-        output_text, result = reader.handle_cpp_directive(input_text)
-        assert result == ref
-        assert output_text is input_text
+    reader = FortranStringReader(input_text)
+    output_text, result = reader.handle_cpp_directive(input_text)
+    assert result == ref
+    assert output_text is input_text
 
 
 def test_reader_cpp_directives():


### PR DESCRIPTION
This is the implementation following the discussion in #248. It should successfully identify any line with '#' as first non-white space character as a cpp directive. For such cases, a new `CppDirective` subclass of `Line` is returned instead.

I suggest merging this before #239 as it allows to identify cpp directives more easily.
Documentation will be updated as part of #239.