### PR TITLE
Fix matching of multichar arguments in PP macro identifier lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Modifications by (in alphabetical order):
 * J. Tiira, University of Helsinki, Finland
 * P. Vitt, University of Siegen, Germany
 
+09/04/2020 PR #254. Fix for >1 character pre-processor macro identifiers.
+
 24/03/2020 PR #239. Add support for CPP directives in fparser2.
 
 07/03/2020 PR #250 for #248. Identify CPP directives in the reader.

--- a/src/fparser/two/C99Preprocessor.py
+++ b/src/fparser/two/C99Preprocessor.py
@@ -494,8 +494,8 @@ class Cpp_Macro_Identifier_List(StringBase):
     subclass_names = []
 
     _pattern = pattern.Pattern('<identifier-list>',
-                               r'\((\s*[A-Za-z_]\w*'
-                               r'(?:\s*,\s*[A-Za-z_])*'
+                               r'\((\s*[A-Za-z_]+\w*'
+                               r'(?:\s*,\s*[A-Za-z_]+)*'
                                r'(?:\s*,\s*\.{3})?|\.{3})?\s*\)')
 
     @staticmethod

--- a/src/fparser/two/C99Preprocessor.py
+++ b/src/fparser/two/C99Preprocessor.py
@@ -494,8 +494,8 @@ class Cpp_Macro_Identifier_List(StringBase):
     subclass_names = []
 
     _pattern = pattern.Pattern('<identifier-list>',
-                               r'\((\s*[A-Za-z_]+\w*'
-                               r'(?:\s*,\s*[A-Za-z_]+)*'
+                               r'\((\s*[A-Za-z_]\w*'
+                               r'(?:\s*,\s*[A-Za-z_]\w*)*'
                                r'(?:\s*,\s*\.{3})?|\.{3})?\s*\)')
 
     @staticmethod

--- a/src/fparser/two/tests/test_c99preprocessor.py
+++ b/src/fparser/two/tests/test_c99preprocessor.py
@@ -239,8 +239,8 @@ def test_incorrect_include_stmt(line):
     '#define report(tst, ...) ((tst)?puts(#tst):printf(__VA_ARGS__))',
     '#define hash_hash # ## #', '#define TABSIZE 100', '#define r(x,y) x ## y',
     '#define MACRO(a, bbb, c_d) (a) * (bbb + c_d)', '#define MACRO x',
-    '#define MACRO( a,b ,   c) (a )*    (   b   + c  )',
-    '#define omp_get_num_threads() 1', '#define MACRO(aaa, b, c)'])
+    '#define MACRO( a,b2_ ,   c) (a )*    (   b2_   + c  )',
+    '#define omp_get_num_threads() 1', '#define MACRO(a2aa, b, c)'])
 def test_macro_stmt(line):
     '''Test that #define is recognized'''
     result = Cpp_Macro_Stmt(line)
@@ -259,7 +259,7 @@ def test_macro_stmt_with_whitespace(line, ref):
 
 @pytest.mark.usefixtures("f2003_create")
 @pytest.mark.parametrize('line', [
-    None, '', ' ', '#def', '#defnie', '#definex',
+    None, '', ' ', '#def', '#defnie', '#definex', '#define 2a'
     '#define fail(...,test) test', '#define', '#define fail(...,...)'])
 def test_incorrect_macro_stmt(line):
     '''Test that incorrectly formed #define statements raise exception'''

--- a/src/fparser/two/tests/test_c99preprocessor.py
+++ b/src/fparser/two/tests/test_c99preprocessor.py
@@ -50,7 +50,6 @@ from fparser.two.C99Preprocessor import (
     Cpp_Include_Stmt, Cpp_Macro_Stmt, Cpp_Macro_Identifier,
     Cpp_Macro_Identifier_List, Cpp_Undef_Stmt, Cpp_Line_Stmt, Cpp_Error_Stmt,
     Cpp_Warning_Stmt, Cpp_Null_Stmt, Cpp_Pp_Tokens)
-from fparser.two.parser import ParserFactory
 from fparser.two.utils import NoMatchError
 from fparser.api import get_reader
 

--- a/src/fparser/two/tests/test_c99preprocessor.py
+++ b/src/fparser/two/tests/test_c99preprocessor.py
@@ -238,9 +238,9 @@ def test_incorrect_include_stmt(line):
     '#define eprintf(...) fprintf (stderr, __VA_ARGS__)',
     '#define report(tst, ...) ((tst)?puts(#tst):printf(__VA_ARGS__))',
     '#define hash_hash # ## #', '#define TABSIZE 100', '#define r(x,y) x ## y',
-    '#define MACRO(a, b, c) (a) * (b + c)', '#define MACRO x',
+    '#define MACRO(a, bbb, c_d) (a) * (bbb + c_d)', '#define MACRO x',
     '#define MACRO( a,b ,   c) (a )*    (   b   + c  )',
-    '#define omp_get_num_threads() 1', '#define MACRO(a, b, c)'])
+    '#define omp_get_num_threads() 1', '#define MACRO(aaa, b, c)'])
 def test_macro_stmt(line):
     '''Test that #define is recognized'''
     result = Cpp_Macro_Stmt(line)


### PR DESCRIPTION
Small fix for an error in the regex responsible for matching the identifier list in the definition of PP macros. This prohibited matching arguments that are longer than 1 character.

The test base was amended accordingly.