### PR TITLE
271 read using UFT8 encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Modifications by (in alphabetical order):
 * B. Reuter, ECMWF, UK
 * J. Tiira, University of Helsinki, Finland
 * P. Vitt, University of Siegen, Germany
+* A. Voysey, UK Met Office
+
+30/11/2020 PR #272 for #271. Bug fix to module_in_file() to ensure that the
+           encoding is always set to UTF-8 when reading a file. 
 
 25/10/2020 PR #256 for #252. Fixes a bug in the parsing of an array constructor.
 

--- a/src/fparser/common/utils.py
+++ b/src/fparser/common/utils.py
@@ -277,7 +277,8 @@ def get_module_file(name, directory, _cache={}):
 def module_in_file(name, filename):
     name = name.lower()
     pattern = re.compile(r'\s*module\s+(?P<name>[a-z]\w*)', re.I).match
-    f = open(filename,'r')
+    encoding = {'encoding': 'UTF-8'}
+    f = io.open(filename,'r',**encoding)
     for line in f:
         m = pattern(line)
         if m and m.group('name').lower()==name:


### PR DESCRIPTION
fixes #271 - uses UTF-8 encoding in `module_in_file()` to allow non-Unicode locales