### PR TITLE
Reset the `cache` of class `FortranParser` to a clean state

### DIFF
--- a/src/fparser/one/tests/test_parsefortran.py
+++ b/src/fparser/one/tests/test_parsefortran.py
@@ -98,6 +98,7 @@ def test_log_cache(log):
                             'warning':  [],
                             'error':    [],
                             'critical': []}
+    _.cache.clear()
 
 
 def test_log_failure(log, monkeypatch):


### PR DESCRIPTION
The PR aims to improve the reliability of the test `test_log_cache` in `test_parsefortran` by resetting the `cache` of class `FortranParser` to a clean state by calling `clear()`.

The test can fail in the following way if `cache` is not in a clean state:
```
>       assert log.messages == {'debug':    [],
                                'info':     [],
                                'warning':  [],
                                'error':    [],
                                'critical': []}
E       AssertionError: assert {'critical': ...thisun'], ...} == {'critical': ...nfo': [], ...}
E         Omitting 4 identical items, use -vv to show
E         Differing items:
E         {'info': ['using cached thisun']} != {'info': []}
E         Use -v to get the full diff
```