### PR TITLE
Resetting `FortranParser.cache` and `log` to the initial state

### DIFF
--- a/src/fparser/one/tests/test_parsefortran.py
+++ b/src/fparser/one/tests/test_parsefortran.py
@@ -62,7 +62,8 @@ def test_log_empty(log):
                             'warning':  [],
                             'error':    [],
                             'critical': []}
-
+    log.reset()
+    unit_under_test.cache.clear()
 
 def test_log_cache(log):
     '''

--- a/src/fparser/one/tests/test_parsefortran.py
+++ b/src/fparser/one/tests/test_parsefortran.py
@@ -62,8 +62,8 @@ def test_log_empty(log):
                             'warning':  [],
                             'error':    [],
                             'critical': []}
-    log.reset()
     unit_under_test.cache.clear()
+
 
 def test_log_cache(log):
     '''
@@ -125,6 +125,7 @@ def test_log_failure(log, monkeypatch):
     assert log.messages['error'] == []
     assert log.messages['critical'][0].startswith('While processing')
     assert log.messages['critical'][1] == 'STOPPED PARSING'
+    unit_under_test.cache.clear()
 
 
 def test_pyf():


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_log_empty` by resetting `FortranParser.cache` and `log` to the initial state by calling method `log.reset` and `cache.clear` respectively.

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 src/fparser/one/tests/test_parsefortran.py::test_log_empty`:

```
>       assert log.messages == {'debug':    [],
                                'info':     ['Nothing to analyze.'],
                                'warning':  [],
                                'error':    [],
                                'critical': []}
E       AssertionError: assert {'critical': ...alyze.'], ...} == {'critical': [...alyze.'], ...}
E         Omitting 4 identical items, use -vv to show
E         Differing items:
E         {'info': ['using cached thingumy', 'Nothing to analyze.']} != {'info': ['Nothing to analyze.']}
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
