### PR TITLE
Fix bug: if construct has name, it must appear in `end` statement

### DIFF
--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -5428,6 +5428,7 @@ class Where_Construct(BlockBase):  # R744
                                    Where_Body_Construct, ],
             End_Where_Stmt, string,
             match_names=True,  # C730
+            strict_match_names=True,
             match_name_classes=(Masked_Elsewhere_Stmt, Elsewhere_Stmt,
                                 End_Where_Stmt),  # C730
             enable_where_construct_hook=True)
@@ -5602,6 +5603,7 @@ class Forall_Construct(BlockBase):  # R752
         return BlockBase.match(
             Forall_Construct_Stmt, [Forall_Body_Construct],
             End_Forall_Stmt, reader, match_names=True,  # C732
+            strict_match_names=True,
         )
 
 
@@ -5866,6 +5868,7 @@ class If_Construct(BlockBase):  # R802
                            Execution_Part_Construct],
             End_If_Stmt, string,
             match_names=True,  # C801
+            strict_match_names=True,
             match_name_classes=(Else_If_Stmt, Else_Stmt, End_If_Stmt),
             enable_if_construct_hook=True)
 
@@ -6075,7 +6078,9 @@ class Case_Construct(BlockBase):  # R808
                                Execution_Part_Construct,
                                Case_Stmt],
             End_Select_Stmt, reader,
-            match_names=True  # C803
+            match_names=True,  # C803
+            strict_match_names=True,
+            match_name_classes=(Case_Stmt)
         )
 
     def tofortran(self, tab='', isfix=None):
@@ -6162,6 +6167,11 @@ class Case_Stmt(StmtBase):  # R810
         if self.items[1] is None:
             return 'CASE %s' % (self.items[0])
         return 'CASE %s %s' % (self.items)
+
+    def get_end_name(self):
+        name = self.items[1]
+        if name is not None:
+            return name.string
 
 
 class End_Select_Stmt(EndStmtBase):  # R811
@@ -6251,6 +6261,7 @@ class Associate_Construct(BlockBase):  # R816
             Associate_Stmt, [Execution_Part_Construct],
             End_Associate_Stmt, reader,
             match_names=True,  # C810
+            strict_match_names=True,
         )
 
 
@@ -6321,7 +6332,10 @@ class Select_Type_Construct(BlockBase):  # R821
         return BlockBase.match(
             Select_Type_Stmt, [Type_Guard_Stmt, Execution_Part_Construct,
                                Type_Guard_Stmt], End_Select_Type_Stmt, reader,
-            match_names=True)  # C819
+            match_names=True,   # C819
+            strict_match_names=True,
+            match_name_classes=(Type_Guard_Stmt),
+        )
 
 
 class Select_Type_Stmt(StmtBase):  # R822
@@ -6417,6 +6431,11 @@ items : ({'TYPE IS', 'CLASS IS', 'CLASS DEFAULT'}, Type_Spec,
         if self.items[2] is not None:
             s += ' %s' % (self.items[2])
         return s
+
+    def get_end_name(self):
+        name = self.items[-1]
+        if name is not None:
+            return name.string
 
 
 class End_Select_Type_Stmt(EndStmtBase):  # R824
@@ -6518,7 +6537,9 @@ class Block_Nonlabel_Do_Construct(BlockBase):  # pylint: disable=invalid-name
         :rtype: string
         '''
         return BlockBase.match(Nonlabel_Do_Stmt, [Execution_Part_Construct],
-                               End_Do_Stmt, reader
+                               End_Do_Stmt, reader,
+                               match_names=True,
+                               strict_match_names=True,
                                )
 
 
@@ -6616,6 +6637,9 @@ class Nonlabel_Do_Stmt(StmtBase, WORDClsBase):  # pylint: disable=invalid-name
         :rtype: string
         '''
         return WORDClsBase.match('DO', Loop_Control, string)
+
+    def get_start_name(self):
+        return self.item.name
 
 
 class Loop_Control(Base):  # pylint: disable=invalid-name

--- a/src/fparser/two/tests/fortran2003/test_associate_construct_r816.py
+++ b/src/fparser/two/tests/fortran2003/test_associate_construct_r816.py
@@ -1,0 +1,134 @@
+# Modified work Copyright (c) 2017-2022 Science and Technology
+# Facilities Council.
+# Original work Copyright (c) 1999-2008 Pearu Peterson
+#
+# All rights reserved.
+#
+# Modifications made as part of the fparser project are distributed
+# under the following license:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# --------------------------------------------------------------------
+
+# The original software (in the f2py project) was distributed under
+# the following license:
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+#   a. Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+#   b. Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#   c. Neither the name of the F2PY project nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+
+import pytest
+from fparser.api import get_reader
+from fparser.two.Fortran2003 import Associate_Construct
+from fparser.two.utils import FortranSyntaxError
+
+
+@pytest.mark.parametrize(
+    "code, expected_string",
+    [
+        (
+            """\
+            ASSOCIATE ( Z => EXP(-(X**2+Y**2)) * COS(THETA) )
+                PRINT *, A+Z, A-Z
+            END ASSOCIATE
+            """,
+            "ASSOCIATE(Z => EXP(- (X ** 2 + Y ** 2)) * COS(THETA))\n"
+            "  PRINT *, A + Z, A - Z\nEND ASSOCIATE",
+        ),
+        (
+            """\
+            name:ASSOCIATE ( XC => AX%B(I,J)%C )
+                XC%DV = XC%DV + PRODUCT(XC%EV(1:N))
+            END ASSOCIATE name
+            """,
+            "name:ASSOCIATE(XC => AX % B(I, J) % C)\n  XC % DV = XC % DV + "
+            "PRODUCT(XC % EV(1 : N))\nEND ASSOCIATE name",
+        ),
+        (
+            """\
+            ASSOCIATE ( W => RESULT(I,J)%W, ZX => AX%B(I,J)%D, ZY => AY%B(I,J)%D )
+                W = ZX*X + ZY*Y
+            END ASSOCIATE
+            """,
+            "ASSOCIATE(W => RESULT(I, J) % W, ZX => AX % B(I, J) % D, ZY => "
+            "AY % B(I, J) % D)\n  W = ZX * X + ZY * Y\nEND ASSOCIATE",
+        ),
+    ],
+)
+def test_associate_construct(fake_symbol_table, code, expected_string):
+
+    obj = Associate_Construct(get_reader(code))
+    assert isinstance(obj, Associate_Construct), repr(obj)
+    assert str(obj) == expected_string
+
+
+def test_end_block_missing_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        Associate_Construct(
+            get_reader(
+                """\
+                name:associate (xc => ax%b(i,j)%c)
+                    xc%dv = xc%dv + product(xc%ev(1:n))
+                end associate
+                """
+            )
+        )
+
+
+def test_end_block_wrong_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        Associate_Construct(
+            get_reader(
+                """\
+                name:associate (xc => ax%b(i,j)%c)
+                    xc%dv = xc%dv + product(xc%ev(1:n))
+                end associate wrong
+                """
+            )
+        )

--- a/src/fparser/two/tests/fortran2003/test_block_do_construct_r826.py
+++ b/src/fparser/two/tests/fortran2003/test_block_do_construct_r826.py
@@ -38,6 +38,7 @@
 import pytest
 from fparser.api import get_reader
 from fparser.common.readfortran import FortranStringReader
+from fparser.two.utils import FortranSyntaxError
 from fparser.two.Fortran2003 import Block_Label_Do_Construct, \
     Block_Nonlabel_Do_Construct
 
@@ -208,3 +209,30 @@ def test_doconstruct_tofortran_non_ascii():
     obj = Block_Nonlabel_Do_Construct(reader)
     out_str = str(obj)
     assert "for e1=1" in out_str
+
+
+def test_do_construct_wrong_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        Block_Nonlabel_Do_Construct(
+            get_reader("""\
+            name: do
+                a = 1
+            end do wrong"""))
+
+
+def test_do_construct_missing_start_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        Block_Nonlabel_Do_Construct(
+            get_reader("""\
+            do
+                a = 1
+            end do name"""))
+
+
+def test_do_construct_missing_end_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        Block_Nonlabel_Do_Construct(
+            get_reader("""\
+            name: do
+                a = 1
+            end do"""))

--- a/src/fparser/two/tests/fortran2003/test_if_construct_r802.py
+++ b/src/fparser/two/tests/fortran2003/test_if_construct_r802.py
@@ -41,6 +41,7 @@ import pytest
 from fparser.api import get_reader
 from fparser.common.readfortran import FortranStringReader
 from fparser.two.Fortran2003 import If_Construct
+from fparser.two.utils import FortranSyntaxError
 
 
 @pytest.mark.usefixtures("f2003_create", "fake_symbol_table")
@@ -176,3 +177,52 @@ def test_ifconstruct_tofortran_non_ascii():
     obj = If_Construct(reader)
     out_str = str(obj)
     assert "for e1=1" in out_str
+
+
+def test_if_construct_wrong_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        If_Construct(
+            get_reader("""\
+            name: if (expr) then
+                a = 1
+            end if wrong"""))
+
+
+def test_if_construct_missing_start_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        If_Construct(
+            get_reader("""\
+            if (expr) then
+                a = 1
+            end if name"""))
+
+
+def test_if_construct_missing_end_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        If_Construct(
+            get_reader("""\
+            name: if (expr) then
+                a = 1
+            end if"""))
+
+
+def test_if_construct_else_wrong_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        If_Construct(
+            get_reader("""\
+            name: if (expr) then
+                a = 1
+            else wrong
+                a = 2
+            end if name"""))
+
+
+def test_if_construct_else_if_wrong_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        If_Construct(
+            get_reader("""\
+            name: if (expr) then
+                a = 1
+            else if (other_expr) then wrong
+                a = 2
+            end if name"""))

--- a/src/fparser/two/tests/fortran2003/test_select_type_construct_r821.py
+++ b/src/fparser/two/tests/fortran2003/test_select_type_construct_r821.py
@@ -1,0 +1,148 @@
+# Modified work Copyright (c) 2017-2022 Science and Technology
+# Facilities Council.
+# Original work Copyright (c) 1999-2008 Pearu Peterson
+#
+# All rights reserved.
+#
+# Modifications made as part of the fparser project are distributed
+# under the following license:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# --------------------------------------------------------------------
+
+# The original software (in the f2py project) was distributed under
+# the following license:
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+#   a. Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+#   b. Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#   c. Neither the name of the F2PY project nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+
+
+import pytest
+from fparser.api import get_reader
+from fparser.two.Fortran2003 import Select_Type_Construct
+from fparser.two.utils import FortranSyntaxError
+
+
+def test_select_type_construct():
+    tcls = Select_Type_Construct
+    tree = tcls(
+        get_reader(
+            """\
+            n:SELECT TYPE ( A => P_OR_C )
+            CLASS IS ( POINT ) n
+            PRINT *, A%X, A%Y ! This block gets executed
+            TYPE IS ( POINT_3D ) n
+            PRINT *, A%X, A%Y, A%Z
+            END SELECT n
+            """,
+            ignore_comments=False,
+        )
+    )
+    assert (
+        str(tree) == "n:SELECT TYPE(A=>P_OR_C)\n"
+        "  CLASS IS (POINT) n\n"
+        "  PRINT *, A % X, A % Y\n"
+        "  ! This block gets executed\n"
+        "  TYPE IS (POINT_3D) n\n"
+        "  PRINT *, A % X, A % Y, A % Z\n"
+        "END SELECT n"
+    )
+
+
+def test_select_type_construct_wrong_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        Select_Type_Construct(
+            get_reader(
+                """\
+            name: select type (n)
+            type is (point)
+                a = 1
+            end select wrong"""
+            )
+        )
+
+
+def test_select_type_construct_missing_start_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        Select_Type_Construct(
+            get_reader(
+                """\
+            select type(n)
+            type is (point)
+                a = 1
+            end select name"""
+            )
+        )
+
+
+def test_select_type_construct_missing_end_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        Select_Type_Construct(
+            get_reader(
+                """\
+            name: select type(n)
+            type is (point)
+                a = 1
+            end select"""
+            )
+        )
+
+
+def test_select_type_construct_select_type_wrong_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        Select_Type_Construct(
+            get_reader(
+                """\
+            name: select type(n)
+            type is (point) wrong
+                a = 1
+            end select name"""
+            )
+        )

--- a/src/fparser/two/tests/fortran2003/test_where_construct_r744.py
+++ b/src/fparser/two/tests/fortran2003/test_where_construct_r744.py
@@ -41,6 +41,7 @@ import pytest
 from fparser.api import get_reader
 from fparser.common.readfortran import FortranStringReader
 from fparser.two.Fortran2003 import Where_Construct
+from fparser.two.utils import FortranSyntaxError
 
 
 @pytest.mark.usefixtures("f2003_create")
@@ -113,3 +114,53 @@ def test_where_tofortran_non_ascii():
     obj = Where_Construct(reader)
     out_str = str(obj)
     assert "for e1=1" in out_str
+
+
+def test_where_construct_wrong_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        Where_Construct(
+            get_reader("""\
+            name: where (expr)
+                a = 1
+            end where wrong"""))
+
+
+def test_where_construct_missing_start_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        Where_Construct(
+            get_reader("""\
+            where (expr)
+                a = 1
+            end where name"""))
+
+
+def test_where_construct_missing_end_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        Where_Construct(
+            get_reader("""\
+            name: where (expr)
+                a = 1
+            end where"""))
+
+
+def test_where_construct_else_wrong_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        Where_Construct(
+            get_reader("""\
+            name: where (expr)
+                a = 1
+            elsewhere wrong
+                a = 2
+            end where name"""))
+
+
+def test_where_construct_else_where_wrong_name(f2003_create, fake_symbol_table):
+    with pytest.raises(FortranSyntaxError):
+        Where_Construct(
+            get_reader("""\
+            name: where (expr)
+                a = 1
+            elsewhere (other_expr) wrong
+                a = 2
+            end where name"""))
+    

--- a/src/fparser/two/tests/test_fortran2003.py
+++ b/src/fparser/two/tests/test_fortran2003.py
@@ -2143,61 +2143,6 @@ def test_case_selector():  # R813
     assert str(obj) == '(2 : 3, c + 2 :, : - a)'
 
 
-@pytest.mark.usefixtures("fake_symbol_table")
-def test_associate_construct():  # R816
-
-    tcls = Associate_Construct
-    obj = tcls(get_reader('''\
-ASSOCIATE ( Z => EXP(-(X**2+Y**2)) * COS(THETA) )
-PRINT *, A+Z, A-Z
-END ASSOCIATE
-    '''))
-    assert isinstance(obj, tcls), repr(obj)
-    assert (str(obj) ==
-            'ASSOCIATE(Z => EXP(- (X ** 2 + Y ** 2)) * COS(THETA))\n'
-            '  PRINT *, A + Z, A - Z\nEND ASSOCIATE')
-
-    obj = tcls(get_reader('''\
-name:ASSOCIATE ( XC => AX%B(I,J)%C )
-XC%DV = XC%DV + PRODUCT(XC%EV(1:N))
-END ASSOCIATE name
-    '''))
-    assert isinstance(obj, tcls), repr(obj)
-    assert (str(obj) ==
-            'name:ASSOCIATE(XC => AX % B(I, J) % C)\n  XC % DV = XC % DV + '
-            'PRODUCT(XC % EV(1 : N))\nEND ASSOCIATE name')
-
-    obj = tcls(get_reader('''\
-ASSOCIATE ( W => RESULT(I,J)%W, ZX => AX%B(I,J)%D, ZY => AY%B(I,J)%D )
-W = ZX*X + ZY*Y
-END ASSOCIATE
-    '''))
-    assert (str(obj) ==
-            'ASSOCIATE(W => RESULT(I, J) % W, ZX => AX % B(I, J) % D, ZY => '
-            'AY % B(I, J) % D)\n  W = ZX * X + ZY * Y\nEND ASSOCIATE')
-
-
-def test_select_type_construct():  # R821
-
-    tcls = Select_Type_Construct
-    tree = tcls(get_reader('''\
-n:SELECT TYPE ( A => P_OR_C )
-CLASS IS ( POINT )
-PRINT *, A%X, A%Y ! This block gets executed
-TYPE IS ( POINT_3D )
-PRINT *, A%X, A%Y, A%Z
-END SELECT n
-    ''', ignore_comments=False))
-    print(str(tree))
-    assert (str(tree) == "n:SELECT TYPE(A=>P_OR_C)\n"
-            "  CLASS IS (POINT)\n"
-            "  PRINT *, A % X, A % Y\n"
-            "  ! This block gets executed\n"
-            "  TYPE IS (POINT_3D)\n"
-            "  PRINT *, A % X, A % Y, A % Z\n"
-            "END SELECT n")
-
-
 def test_select_type_stmt():  # R822
 
     tcls = Select_Type_Stmt

--- a/src/fparser/two/utils.py
+++ b/src/fparser/two/utils.py
@@ -504,7 +504,8 @@ class BlockBase(Base):
               enable_do_label_construct_hook=False,
               enable_if_construct_hook=False,
               enable_where_construct_hook=False,
-              strict_order=False):
+              strict_order=False,
+              strict_match_names=False):
         '''
         Checks whether the content in reader matches the given
         type of block statement (e.g. DO..END DO, IF...END IF etc.)
@@ -525,6 +526,8 @@ class BlockBase(Base):
         :param bool enable_where_construct_hook: TBD
         :param bool strict_order: whether to enforce the order of the \
                                   given subclasses.
+        :param bool strict_match_names: if start name present, end name \
+                                        must exist and match
 
         :return: instance of startcls or None if no match is found
         :rtype: startcls
@@ -620,10 +623,14 @@ class BlockBase(Base):
                         raise FortranSyntaxError(
                             reader, "Name '{0}' has no corresponding starting "
                             "name".format(end_name))
+                    elif strict_match_names and start_name and not end_name:
+                        raise FortranSyntaxError(
+                            reader, "Expecting name '{0}' but none given".format(
+                                start_name))
                     if end_name and start_name and \
                        end_name.lower() != start_name.lower():
                         raise FortranSyntaxError(
-                            reader, "Expecting name '{0}'".format(start_name))
+                            reader, "Expecting name '{0}', got '{1}'".format(start_name, end_name))
 
                 if endcls is not None and isinstance(obj, endcls_all):
                     if match_labels:
@@ -636,16 +643,21 @@ class BlockBase(Base):
                         start_name, end_name = (content[start_idx].
                                                 get_start_name(),
                                                 content[-1].get_end_name())
+
                         if end_name and not start_name:
                             raise FortranSyntaxError(
                                 reader,
                                 "Name '{0}' has no corresponding starting "
                                 "name".format(end_name))
+                        elif strict_match_names and start_name and not end_name:
+                            raise FortranSyntaxError(
+                                reader, "Expecting name '{0}' but none given".format(
+                                    start_name))
                         elif start_name and end_name and (start_name.lower() !=
                                                           end_name.lower()):
                             raise FortranSyntaxError(
-                                reader, "Expecting name '{0}'".format(
-                                    start_name))
+                                reader, "Expecting name '{0}', got '{1}'".format(
+                                    start_name, end_name))
                     # We've found the enclosing end statement so break out
                     found_end = True
                     break


### PR DESCRIPTION
Affects following block constructs:
- `associate`
- `do` (non-label)
- `if`
- `select case`
- `select type`
- `where`

This more strictly implements the constraints on the various blocks, which all have wording similar to the `do-construct`:

> C821 If the _do-stmt_ of a _block-do-construct_ specifies a _do-construct-name_, the corresponding
_end-do_ shall be an _end-do-stmt_ specifying the same _do-construct-name_. If the _do-stmt_ of a
_block-do-construct_ does not specify a _do-construct-name_, the corresponding _end-do_ shall not
specify a _do-construct-name_.

Basically, if you use `name: do`, you _must_ use `end do name`.