### PR TITLE
Automate packaging

### DIFF
--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -1,0 +1,26 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build --sdist --wheel
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_DEPLOYMENT_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = [
+    "setuptools >= 42",
+    "setuptools_scm[toml] >= 6.2",
+    "setuptools_scm_git_archive",
+    "wheel >= 0.29.0",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "src/fparser/_version.py"
+git_describe_command = "git describe --dirty --tags --long --first-parent"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,54 @@
+[metadata]
+name = fparser
+author = Andrew Porter
+author_email = trackstand.andy@gmail.com
+license = BSD 3-Clause License
+url = https://github.com/stfc/fparser
+description = The fparser project
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers =
+    Development Status :: 3 - Alpha
+    Environment :: Console
+    Intended Audience :: Developers
+    Intended Audience :: Science/Research
+    Natural Language :: English
+    Programming Language :: Fortran
+    Programming Language :: Python
+    Topic :: Scientific/Engineering
+    Topic :: Software Development
+    Topic :: Utilities
+    Operating System :: POSIX
+    Operating System :: Unix
+    Operating System :: MacOS
+project_urls =
+    Source = https://github.com/stfc/fparser
+    Tracker = https://github.com/stfc/fparser/issues
+    Documentation = https://fparser.readthedocs.io/en/latest/
+
+[options]
+package_dir =
+    =src
+packages = find:
+# We need the following line to ensure we get the fparser/log.config
+# file installed.
+include_package_data = True
+install_requires =
+    six
+    importlib-metadata; python_version >= "3.6"
+
+[options.packages.find]
+where=src
+
+[options.extras_require]
+doc =
+    sphinx
+    sphinx_rtd_theme
+tests = pytest >= 3.3.0
+
+[options.entry_points]
+console_scripts =
+    fparser2 = fparser.scripts.fparser2:main
+
+[build_sphinx]
+source-dir = doc

--- a/setup.py
+++ b/setup.py
@@ -67,68 +67,11 @@
 
 """Setup script. Used by easy_install and pip."""
 
-from setuptools import setup, find_packages
-
-PACKAGES = find_packages(where="src")
-
-NAME = 'fparser'
-AUTHOR = 'Andrew Porter'
-AUTHOR_EMAIL = 'trackstand.andy@gmail.com'
-URL = 'https://github.com/stfc/fparser'
-DOWNLOAD_URL = 'https://github.com/stfc/fparser'
-DESCRIPTION = 'The fparser Project'
-LONG_DESCRIPTION = '''\
-The fparser project is created to develop a parser for
-Fortran 77..2008 code. It is based on the work of Pearu Peterson in
-the F2PY project (http://www.f2py.com).
-
-See https://github.com/stfc/fparser for more information.
-'''
-LICENSE = 'OSI Approved :: BSD 3-Clause License'
-
-CLASSIFIERS = [
-    'Development Status :: 3 - Alpha',
-    'Environment :: Console',
-    'Intended Audience :: Developers',
-    'Intended Audience :: Science/Research',
-    'Natural Language :: English',
-    'Programming Language :: Fortran',
-    'Programming Language :: Python',
-    'Topic :: Scientific/Engineering',
-    'Topic :: Software Development',
-    'Topic :: Utilities',
-    'Operating System :: POSIX',
-    'Operating System :: Unix',
-    'Operating System :: MacOS']
+from setuptools import setup
 
 MAJOR = 0
 MINOR = 0
 MICRO = 14
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
-if __name__ == '__main__':
-
-    setup(
-        name=NAME,
-        version=VERSION,
-        author=AUTHOR,
-        author_email=(AUTHOR_EMAIL),
-        license=LICENSE,
-        url=URL,
-        description=DESCRIPTION,
-        long_description=LONG_DESCRIPTION,
-        classifiers=CLASSIFIERS,
-        packages=PACKAGES,
-        package_dir={"": "src"},
-        install_requires=['six'],
-        extras_require={
-            'doc': ["sphinx", "sphinx_rtd_theme"]
-        },
-        entry_points={
-            'console_scripts': [
-                'fparser2=fparser.scripts.fparser2:main',
-            ],
-        },
-        # We need the following line to ensure we get the fparser/log.config
-        # file installed.
-        include_package_data=True)
+setup()

--- a/src/fparser/__init__.py
+++ b/src/fparser/__init__.py
@@ -65,7 +65,20 @@
 # First version by: Pearu Peterson <pearu@cens.ioc.ee>
 # First created: Oct 2006
 
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ModuleNotFoundError:
+    from importlib_metadata import version, PackageNotFoundError
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    from setuptools_scm import get_version
+
+    __version__ = get_version(root="..", relative_to=__file__)
+
 import logging
 
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+__all__ = ["__version__"]


### PR DESCRIPTION
Closes #324 

This requires a [PyPI API token](https://pypi.org/help/#apitoken) to be added as a secret named `PYPI_DEPLOYMENT_TOKEN` to this repo. Once that's been added, every new GitHub release will automatically trigger building a package and uploading to PyPI.

This now sets the version from the latest git tag using [setuptools_scm](https://github.com/pypa/setuptools_scm), so for instance, the latest commit on this branch is:

```
$  python -c "import fparser; print(fparser.__version__)"
0.0.15.dev4+g877584c
```

Note that this version is only updated on `pip install`, even for editable installs.

Also, I note that `fparser2 --version` doesn't work, I suspect because you're using `optparse`. I'm happy to look at upgrading to `argparse` which would give you that for free.