### PR TITLE
#362 Dependency example: support files in subdirectories.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Modifications by (in alphabetical order):
 * P. Vitt, University of Siegen, Germany
 * A. Voysey, UK Met Office
 
+08/08/2022 PR #363 for #363. Extends the dependency-analysis example utility
+           to cope with files in subdirectories.
+
 26/07/2022 PR #341 - replace staticmethod calls with decorator.
 
 14/07/2022 PR #361 - remove six dependency from setup.py

--- a/example/README.md
+++ b/example/README.md
@@ -11,11 +11,17 @@ parsed code to stdout.
 This program prints dependencies between Fortran source files to stdout,
 in a format suitable to be used in a Makefile. Usage:
 
-	$ $(PATH_TO_FPARSER)/example/create_dependencies.py *f90
-	configuration_mod.o: base_mesh_config_mod.o extrusion_uniform_config_mod.o \
-		finite_element_config_mod.o io_utility_mod.o partitioning_config_mod.o \
-		perturbation_bell_config_mod.o planet_config_mod.o timestepping_config_mod.o
-	write_diagnostics_mod.o: write_methods_mod.o
+	  $ $(PATH_TO_FPARSER)/example/create_dependencies.py *f90
+	  configuration_mod.o: base_mesh_config_mod.o extrusion_uniform_config_mod.o \
+		  finite_element_config_mod.o io_utility_mod.o partitioning_config_mod.o \
+		  perturbation_bell_config_mod.o planet_config_mod.o timestepping_config_mod.o
+	  write_diagnostics_mod.o: write_methods_mod.o
+
+It also supports files in subdirectories, e.g.:
+
+    fparser/example$ ./create_dependencies.py  test_files/*f90
+    test_files/b.o: test_files/a.o
+    test_files/c.o: test_files/a.o test_files/b.o
 
 ### Known issues:
 - If you do not have ``python`` in your path (e.g. you have only ``python3``
@@ -31,12 +37,12 @@ in a format suitable to be used in a Makefile. Usage:
 
   	  use mymodule
 
-  then it will look for any of the files ``mymodule.f90``, ``mymodule.F90``,
-  or ``mymodule.x90`` (the latter to support a coding style used in PSyclone).
-  If none of these files is found, no dependencies will be printed for this
-  case. You can modify the ``create_dependency.py`` script if you are using
-  a different naming style for your files (see lines 101 to 107 in the
-  script).
+  then it will look for a file with the 'root' name ``mymodule``, e.g.  it
+  would use ``mymodule.f90``, ``mymodule.F90``, or ``mymodule.x90`` in the
+  list of files provided as argument. If no matching file is found, no
+  dependencies will be printed for this case, it will be silently ignored.
+  You can modify the ``create_dependency.py`` script if you are using a
+   different naming style for your files (see lines 120 to 123 in the script).
 
 ### Todo
 - Remove the need for a file naming convention by parsing all files, and then
@@ -45,3 +51,6 @@ in a format suitable to be used in a Makefile. Usage:
 
       $ ./create_dependencies.py -l NETCDF_LIB=/opt/mynetcdf-dir my_netcdf_source.f90
       my_netcdf_source.o: $(NETCDF_LIB)
+- Provide a list of modules to ignore, and abort the script if a reference
+  to a module is found that is unknown (i.e. neither provided in a file name
+  nor in the list of modules to ignore).

--- a/example/README.md
+++ b/example/README.md
@@ -31,18 +31,18 @@ It also supports files in subdirectories, e.g.:
   or modify the first line of the script to use ``python3`` instead of
   ``python``.
 - The script will only detect dependencies from the files specified on the
-  command line to files in the current directory. It assumes that the name in
-  the ``use`` statement is the same as the file name that stores the module.
+  command line to files provided on the command line. It assumes that the name
+  in the ``use`` statement is the same as the file name that stores the module.
   For example, if your code has:
 
   	  use mymodule
 
-  then it will look for a file with the 'root' name ``mymodule``, e.g.  it
-  would use ``mymodule.f90``, ``mymodule.F90``, or ``mymodule.x90`` in the
-  list of files provided as argument. If no matching file is found, no
+  then the script will look for a file with the 'root' name ``mymodule``,
+  e.g. it would use ``mymodule.f90``, ``mymodule.F90``, or ``mymodule.x90``
+  in the list of files provided as argument. If no matching file is found, no
   dependencies will be printed for this case, it will be silently ignored.
   You can modify the ``create_dependency.py`` script if you are using a
-   different naming style for your files (see lines 120 to 123 in the script).
+  different naming style for your files (see lines 120 to 123 in the script).
 
 ### Todo
 - Remove the need for a file naming convention by parsing all files, and then

--- a/example/create_dependencies.py
+++ b/example/create_dependencies.py
@@ -60,8 +60,21 @@ def usage():
     """This function prints the usage information and exits. It is called if
     incorrect input parameters are supplied.
     """
-    print("{0} file1 [file2...]".format(sys.argv[0]))
+    print("{argv[0]} file1 [file2...]")
     sys.exit(-1)
+
+
+# -----------------------------------------------------------------------------
+def get_root(file_name):
+    """This function returns the 'root' of a file, which is the filename
+    without any path component and without an extension. E.g.:
+    `dir1/dir2/myfile.x90` would return `myfile`.
+    :param str file_name: the name of the file.
+    :returns: the root of the name of the file.
+    :rtype: str
+    """
+
+    return os.path.splitext(os.path.basename(file_name))[0]
 
 
 # -----------------------------------------------------------------------------
@@ -74,6 +87,19 @@ if __name__ == "__main__":
     # pylint: disable=invalid-name
     all_files = sys.argv[1:]
 
+    # Create a look-up directories that maps the filenames without
+    # path and extensions to the full filename:
+    lookup_files = {}
+    for file in all_files:
+        root = get_root(file)
+        if root in lookup_files:
+            print(
+                f"The file '{file}' has the same root '{root}' as "
+                f"the file '{lookup_files[root]}'."
+            )
+            sys.exit(-1)
+        lookup_files[get_root(file)] = file
+
     # Sort the input file names, so that they are output alphabetically
     all_files.sort()
     for filename in all_files:
@@ -82,7 +108,7 @@ if __name__ == "__main__":
         try:
             reader = FortranFileReader(filename)
         except IOError:
-            print("Could not open file '{0}'.".format(filename), file=sys.stderr)
+            print(f"Could not open file '{filename}'.", file=sys.stderr)
             sys.exit(-1)
 
         parser = ParserFactory().create(std="f2003")
@@ -91,21 +117,21 @@ if __name__ == "__main__":
         # Collect all used modules in a list
         all_use = []
         for node in walk(parse_tree, Use_Stmt):
-            use_name = str(node.items[2])
-            # Nothing else to do if the name is already in the list:
-            if use_name + ".o" in all_use:
-                continue
-
             # If you want to implement a specific naming convention,
             # you can modify the content of 'use_name' here. For example,
             # you could remove a '_mod' at the end if your file names do
             # not contains this.
-            if (
-                os.path.isfile(use_name + ".f90")
-                or os.path.isfile(use_name + ".x90")
-                or os.path.isfile(use_name + ".F90")
-            ):
-                all_use.append(use_name + ".o")
+            use_name = str(node.items[2])
+
+            if use_name not in lookup_files:
+                # Silently ignore modules we can't find, assuming
+                # that they are system dependencies (e.g. MPI.mod)
+                continue
+
+            obj_dependency = os.path.splitext(lookup_files[use_name])[0] + ".o"
+            # Only add dependencies that are not already in the list:
+            if obj_dependency not in all_use:
+                all_use.append(obj_dependency)
 
         # Now output all dependencies for this file (if any):
         if all_use:

--- a/example/create_dependencies.py
+++ b/example/create_dependencies.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     all_files = sys.argv[1:]
 
     # Create a mapping of filenames without path and extensions to the
-    # full filename"
+    # full filename.
     lookup_files = {}
     for file in all_files:
         root = get_root(file)

--- a/example/create_dependencies.py
+++ b/example/create_dependencies.py
@@ -60,7 +60,7 @@ def usage():
     """This function prints the usage information and exits. It is called if
     incorrect input parameters are supplied.
     """
-    print("{argv[0]} file1 [file2...]")
+    print(f"{sys.argv[0]} file1 [file2...]")
     sys.exit(-1)
 
 
@@ -69,11 +69,13 @@ def get_root(file_name):
     """This function returns the 'root' of a file, which is the filename
     without any path component and without an extension. E.g.:
     `dir1/dir2/myfile.x90` would return `myfile`.
+
     :param str file_name: the name of the file.
+
     :returns: the root of the name of the file.
     :rtype: str
-    """
 
+    """
     return os.path.splitext(os.path.basename(file_name))[0]
 
 
@@ -87,8 +89,8 @@ if __name__ == "__main__":
     # pylint: disable=invalid-name
     all_files = sys.argv[1:]
 
-    # Create a look-up directories that maps the filenames without
-    # path and extensions to the full filename:
+    # Create a mapping of filenames without path and extensions to the
+    # full filename"
     lookup_files = {}
     for file in all_files:
         root = get_root(file)
@@ -98,7 +100,7 @@ if __name__ == "__main__":
                 f"the file '{lookup_files[root]}'."
             )
             sys.exit(-1)
-        lookup_files[get_root(file)] = file
+        lookup_files[root] = file
 
     # Sort the input file names, so that they are output alphabetically
     all_files.sort()


### PR DESCRIPTION
This is a small improvement to the Fortran dependency creation to support files in subdirectories, e.g.:
```
field/integer_field_mod.o: constants_mod.o count_mod.o field/field_parent_mod.o \
        field/pure_abstract_field_mod.o function_space_mod.o log_mod.o mesh_mod.o \
        mpi_mod.o
```
I.e. the subdirectories are added where applicable (this shows work in progress with the PSyclone LFRic infrastructure files, where only one subdirectory, ``field``, has been created - i.e. all other files are indeed still in the base directory).