### PR TITLE
Fix parsing of format-items with hollerith items and omitted commas

### DIFF
--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -8933,9 +8933,6 @@ class Format_Item_List(SequenceBase):  # pylint: disable=invalid-name
                 else:
                     item_list.append(Format_Item(repmap(line)))
                     current_string = ""
-        if len(item_list) == 0:
-            # a list must contain at least 1 item (see SequenceBase)
-            return None
         return ",", tuple(item_list)
 
 

--- a/src/fparser/two/tests/fortran2003/test_format_item_list.py
+++ b/src/fparser/two/tests/fortran2003/test_format_item_list.py
@@ -134,6 +134,23 @@ def test_hollerith_only_spaces(f2003_create, monkeypatch):
     )
 
 
+def test_hollerith_slash(f2003_create, monkeypatch):
+    """Check that a hollerith item is parsed correctly when preceeded by a
+    slash without a separating comma.
+
+    """
+    from fparser.two import utils
+
+    monkeypatch.setattr(utils, "EXTENSIONS", ["hollerith"])
+    myinput = "/3Habc"
+    ast = Format_Item_List(myinput)
+    assert str(ast) == "/, 3Habc"
+    assert repr(ast) == (
+        "Format_Item_List(',', (Control_Edit_Desc(None, '/'), "
+        "Hollerith_Item('abc')))"
+    )
+
+
 def test_errors(f2003_create, monkeypatch):
     """test some list errors. Individual item errors will be picked up by
     the subclasses.

--- a/src/fparser/two/tests/fortran2003/test_format_item_list.py
+++ b/src/fparser/two/tests/fortran2003/test_format_item_list.py
@@ -134,21 +134,54 @@ def test_hollerith_only_spaces(f2003_create, monkeypatch):
     )
 
 
-def test_hollerith_slash(f2003_create, monkeypatch):
+def test_hollerith_omitted_comma_before(f2003_create, monkeypatch):
     """Check that a hollerith item is parsed correctly when preceeded by a
-    slash without a separating comma.
+    slash or colon without a separating comma.
 
     """
     from fparser.two import utils
 
     monkeypatch.setattr(utils, "EXTENSIONS", ["hollerith"])
-    myinput = "/3Habc"
+    for item in ["/", ":"]:
+        myinput = "{0}3Habc".format(item)
+        ast = Format_Item_List(myinput)
+        assert str(ast) == "{0}, 3Habc".format(item)
+        assert repr(ast) == (
+            "Format_Item_List(',', (Control_Edit_Desc(None, '{0}'), "
+            "Hollerith_Item('abc')))"
+        ).format(item)
+
+
+def test_hollerith_omitted_comma_after(f2003_create, monkeypatch):
+    """Check that a hollerith item is parsed correctly when followed by a
+    slash or colon without a separating comma.
+
+    """
+    from fparser.two import utils
+
+    monkeypatch.setattr(utils, "EXTENSIONS", ["hollerith"])
+    for item in ["/", ":"]:
+        myinput = "3Habc{0}".format(item)
+        ast = Format_Item_List(myinput)
+        assert str(ast) == "3Habc, {0}".format(item)
+        assert repr(ast) == (
+            "Format_Item_List(',', (Hollerith_Item('abc'), "
+            "Control_Edit_Desc(None, '{0}')))"
+        ).format(item)
+
+
+def test_hollerith_trailing_space(f2003_create, monkeypatch):
+    """Check that a hollerith item is parsed correctly at the end of a list
+    when it contains a trailing space.
+
+    """
+    from fparser.two import utils
+
+    monkeypatch.setattr(utils, "EXTENSIONS", ["hollerith"])
+    myinput = "4Habc "
     ast = Format_Item_List(myinput)
-    assert str(ast) == "/, 3Habc"
-    assert repr(ast) == (
-        "Format_Item_List(',', (Control_Edit_Desc(None, '/'), "
-        "Hollerith_Item('abc')))"
-    )
+    assert str(ast) == "4Habc "
+    assert repr(ast) == "Format_Item_List(',', (Hollerith_Item('abc '),))"
 
 
 def test_errors(f2003_create, monkeypatch):

--- a/src/fparser/two/tests/fortran2003/test_format_item_list.py
+++ b/src/fparser/two/tests/fortran2003/test_format_item_list.py
@@ -45,6 +45,7 @@ Fortran95. However, Fortran compilers still support it.
 import pytest
 from fparser.two.Fortran2003 import Format_Item_List
 from fparser.two.utils import NoMatchError
+from fparser.two import utils
 
 
 def test_non_hollerith(f2003_create):
@@ -139,17 +140,16 @@ def test_hollerith_omitted_comma_before(f2003_create, monkeypatch):
     slash or colon without a separating comma.
 
     """
-    from fparser.two import utils
 
     monkeypatch.setattr(utils, "EXTENSIONS", ["hollerith"])
     for item in ["/", ":"]:
-        myinput = "{0}3Habc".format(item)
+        myinput = f"{item}3Habc"
         ast = Format_Item_List(myinput)
-        assert str(ast) == "{0}, 3Habc".format(item)
+        assert str(ast) == f"{item}, 3Habc"
         assert repr(ast) == (
-            "Format_Item_List(',', (Control_Edit_Desc(None, '{0}'), "
+            f"Format_Item_List(',', (Control_Edit_Desc(None, '{item}'), "
             "Hollerith_Item('abc')))"
-        ).format(item)
+        )
 
 
 def test_hollerith_omitted_comma_after(f2003_create, monkeypatch):
@@ -157,17 +157,16 @@ def test_hollerith_omitted_comma_after(f2003_create, monkeypatch):
     slash or colon without a separating comma.
 
     """
-    from fparser.two import utils
 
     monkeypatch.setattr(utils, "EXTENSIONS", ["hollerith"])
     for item in ["/", ":"]:
-        myinput = "3Habc{0}".format(item)
+        myinput = f"3Habc{item}"
         ast = Format_Item_List(myinput)
-        assert str(ast) == "3Habc, {0}".format(item)
+        assert str(ast) == f"3Habc, {item}"
         assert repr(ast) == (
             "Format_Item_List(',', (Hollerith_Item('abc'), "
-            "Control_Edit_Desc(None, '{0}')))"
-        ).format(item)
+            f"Control_Edit_Desc(None, '{item}')))"
+        )
 
 
 def test_hollerith_trailing_space(f2003_create, monkeypatch):
@@ -175,7 +174,6 @@ def test_hollerith_trailing_space(f2003_create, monkeypatch):
     when it contains a trailing space.
 
     """
-    from fparser.two import utils
 
     monkeypatch.setattr(utils, "EXTENSIONS", ["hollerith"])
     myinput = "4Habc "

--- a/src/fparser/two/tests/fortran2003/test_format_item_r1003.py
+++ b/src/fparser/two/tests/fortran2003/test_format_item_r1003.py
@@ -116,9 +116,10 @@ def test_format_list_descriptor(f2003_create):
         ast = Format_Item(my_input)
         assert my_input.replace(" ", "") in str(ast)
         assert repr(ast) == (
-            "Format_Item(None, Format_Item(None, Data_Edit"
-            "_Desc_C1002('F', Digit_String('2', None), Int"
-            "_Literal_Constant('2', None), None)))"
+            "Format_Item(None, Format_Item_List(',', ("
+            "Format_Item(None, Data_Edit_Desc_C1002('F', "
+            "Digit_String('2', None), Int_Literal_Constant("
+            "'2', None), None)),)))"
         )
     # R
     for my_input in ["2(F2.2)", " 2 (F2.2) ", " 2 ( F2.2 ) "]:
@@ -126,9 +127,9 @@ def test_format_list_descriptor(f2003_create):
         assert my_input.replace(" ", "") in str(ast)
         assert repr(ast) == (
             "Format_Item(Digit_String('2', None), Format_"
-            "Item(None, Data_Edit_Desc_C1002('F', Digit_"
-            "String('2', None), Int_Literal_Constant('2'"
-            ", None), None)))"
+            "Item_List(',', (Format_Item(None, Data_Edit_"
+            "Desc_C1002('F', Digit_String('2', None), Int_"
+            "Literal_Constant('2', None), None)),)))"
         )
 
 

--- a/src/fparser/two/tests/test_fortran2003.py
+++ b/src/fparser/two/tests/test_fortran2003.py
@@ -2774,7 +2774,7 @@ def test_format_item_list():  # R1002, R1003
 
     tcls = Format_Item_List
     obj = tcls("3f9.4")
-    assert isinstance(obj, Format_Item), repr(type(obj))
+    assert isinstance(obj, Format_Item_List), repr(type(obj))
     assert str(obj) == "3F9.4"
 
     obj = tcls("3f9.4, 2f8.1")

--- a/src/fparser/two/tests/test_fortran2003.py
+++ b/src/fparser/two/tests/test_fortran2003.py
@@ -2729,6 +2729,9 @@ def test_format_item():  # R1003
     obj = tcls("'(5X,\"q_mesh =\",4F12.8)'")
     assert isinstance(obj, Char_Literal_Constant)
 
+    obj = tcls("3/' '")
+    assert str(obj) == "3/, ' '"
+
 
 def test_data_edit_desc():
     """Tests for matching Edit Descriptors (R1005)."""


### PR DESCRIPTION
This fixes parsing of hollerith items in `format-items` in three cases:
- Omitted comma before a hollerith item: `/3Habc`
- Omitted comma after a hollerith item: `3Habc/`
- Trailing whitespace in trailing hollerith item: `4Hspc `

It also changes `Format_Item_List` to match single item lists rather than bail out and rely on `Format_Item`. This matches the behavior of `SequenceBase` and all the generated lists.