### PR TITLE
Fix trailing whitespace being lost when Format_Item_List is in parentheses

### DIFF
--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -9302,7 +9302,7 @@ class Format_Item(Base):  # pylint: disable=invalid-name
         # match method. Other matches are performed by the subclasses.
         if my_string[0] == "(" and my_string[-1] == ")":
             # This could be a format-item-list
-            rest = Format_Item_List(my_string[1:-1].strip())
+            rest = Format_Item_List(my_string[1:-1].lstrip())
         else:
             # This is not a format-item-list so see if it is a
             # data-edit-descriptor

--- a/src/fparser/two/tests/fortran2003/test_format_item_r1003.py
+++ b/src/fparser/two/tests/fortran2003/test_format_item_r1003.py
@@ -42,6 +42,7 @@ Fortran95. However, Fortran compilers still support it.
 import pytest
 from fparser.two.Fortran2003 import Format_Item
 from fparser.two.utils import NoMatchError, InternalError
+from fparser.two import utils
 
 
 def test_data_edit_descriptor(f2003_create):
@@ -131,6 +132,18 @@ def test_format_list_descriptor(f2003_create):
             "Desc_C1002('F', Digit_String('2', None), Int_"
             "Literal_Constant('2', None), None)),)))"
         )
+
+
+def test_format_list_descriptor_trailing_space(f2003_create, monkeypatch):
+    """Check that format item list descriptors preserve trailing space."""
+
+    monkeypatch.setattr(utils, "EXTENSIONS", ["hollerith"])
+    myinput = "(4Habc )"
+    ast = Format_Item(myinput)
+    assert str(ast) == myinput
+    assert repr(ast) == (
+        "Format_Item(None, Format_Item_List(',', (Hollerith_Item('abc '),)))"
+    )
 
 
 def test_hollerith_item(f2003_create, monkeypatch):

--- a/src/fparser/two/tests/utils/test_bracket_base.py
+++ b/src/fparser/two/tests/utils/test_bracket_base.py
@@ -99,27 +99,30 @@ def test_cls():
             )
 
 
-def test_trailing_whitespace():
+@pytest.mark.parametrize("require", [False, True])
+@pytest.mark.parametrize(
+    "lhs, rhs",
+    [
+        ("(", ")"),
+        (" ( ", " ) "),
+        ("[", "]"),
+        ("A", "A"),
+        ("([", "])"),
+        ("{{[(", ")]}}"),
+    ],
+)
+def test_trailing_whitespace(require, lhs, rhs):
     """Test that the BracketBase match method passes any trailing whitespace
     within the brackets to the specified class.
     """
-    for require in [False, True]:
-        for lhs, rhs in [
-            ("(", ")"),
-            (" ( ", " ) "),
-            ("[", "]"),
-            ("A", "A"),
-            ("([", "])"),
-            ("{{[(", ")]}}"),
-        ]:
-            brackets = lhs + rhs
-            input_text = lhs + "4habc " + rhs
-            result = BracketBase.match(
-                brackets, Hollerith_Item, input_text, require_cls=require
-            )
-            assert str(result) == "('{0}', Hollerith_Item('abc '), '{1}')".format(
-                lhs.replace(" ", ""), rhs.replace(" ", "")
-            )
+    brackets = lhs + rhs
+    input_text = lhs + "4habc " + rhs
+    result = BracketBase.match(
+        brackets, Hollerith_Item, input_text, require_cls=require
+    )
+    assert str(result) == "('{0}', Hollerith_Item('abc '), '{1}')".format(
+        lhs.replace(" ", ""), rhs.replace(" ", "")
+    )
 
 
 def test_brackets_error1():

--- a/src/fparser/two/tests/utils/test_bracket_base.py
+++ b/src/fparser/two/tests/utils/test_bracket_base.py
@@ -37,7 +37,7 @@ utils.py"""
 
 import pytest
 from fparser.two.utils import BracketBase, InternalError
-from fparser.two.Fortran2003 import Name
+from fparser.two.Fortran2003 import Name, Hollerith_Item
 
 
 def test_brackets():
@@ -95,6 +95,29 @@ def test_cls():
             input_text = lhs + "hello" + rhs
             result = BracketBase.match(brackets, Name, input_text, require_cls=require)
             assert str(result) == "('{0}', Name('hello'), '{1}')".format(
+                lhs.replace(" ", ""), rhs.replace(" ", "")
+            )
+
+
+def test_trailing_whitespace():
+    """Test that the BracketBase match method passes any trailing whitespace
+    within the brackets to the specified class.
+    """
+    for require in [False, True]:
+        for lhs, rhs in [
+            ("(", ")"),
+            (" ( ", " ) "),
+            ("[", "]"),
+            ("A", "A"),
+            ("([", "])"),
+            ("{{[(", ")]}}"),
+        ]:
+            brackets = lhs + rhs
+            input_text = lhs + "4habc " + rhs
+            result = BracketBase.match(
+                brackets, Hollerith_Item, input_text, require_cls=require
+            )
+            assert str(result) == "('{0}', Hollerith_Item('abc '), '{1}')".format(
                 lhs.replace(" ", ""), rhs.replace(" ", "")
             )
 

--- a/src/fparser/two/utils.py
+++ b/src/fparser/two/utils.py
@@ -1260,7 +1260,7 @@ class BracketBase(Base):
             return None
         # Check whether or not there's anything between the open
         # and close brackets
-        line = string_strip[bracket_len:-bracket_len].strip()
+        line = string_strip[bracket_len:-bracket_len].lstrip()
         if (not line and cls and require_cls) or (line and not cls):
             return None
         if not line and (not cls or not require_cls):


### PR DESCRIPTION
Such trailing whitespace is important for `Hollerith_Item`s which may occur at the end of a `Format_Item_List` and require trailing whitespace.

This actually fixes `BracketBase` consuming trailing whitespace anywhere. I believe this is fine because all the `match` implementations I've seen strip their input before processing.