### PR TITLE
(Towards #379) ensure symbol table cleanly ignores operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Modifications by (in alphabetical order):
 * P. Vitt, University of Siegen, Germany
 * A. Voysey, UK Met Office
 
+18/10/2022 PR #380 towards #379. Improve support for operators and symbol
+           renaming in the use construct.
+
 18/10/2022 PR #369 for #332. Add support for F2008 open intrinsic arguments.
 
 13/10/2022 PR #381 for #298. Fix F2008 allocate statement with arguments.

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -10302,13 +10302,14 @@ class Use_Stmt(StmtBase):  # pylint: disable=invalid-name
                     for child in result[4].children:
                         if isinstance(child, Name):
                             only_list.append((child.string, None))
-                        elif isinstance(child, Rename) and not child.children[0]:
-                            # This is a Rename of a symbol rather than an operator
-                            # (which would have child.children[0] == 'OPERATOR'.
-                            # TODO #379 - support operators.
-                            only_list.append(
-                                (child.children[1].string, child.children[2].string)
-                            )
+                        elif isinstance(child, Rename):
+                            if not child.children[0]:
+                                # This is a Rename of a symbol rather than an operator
+                                # (which would have child.children[0] == 'OPERATOR'.
+                                # TODO #379 - support operators.
+                                only_list.append(
+                                    (child.children[1].string, child.children[2].string)
+                                )
                         elif isinstance(child, Generic_Spec):
                             # For now we ignore anything other than symbol names
                             # and this includes operators (TODO #379).

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -10273,6 +10273,9 @@ class Use_Stmt(StmtBase):  # pylint: disable=invalid-name
         use statements in the symbol table associated with the current scope
         (if there is one).
 
+        TODO #379 - currently operator imports/renaming are not captured in
+                    the symbol table.
+
         :param str string: Fortran code to check for a match.
 
         :return: 5-tuple containing strings and instances of the classes
@@ -10299,22 +10302,34 @@ class Use_Stmt(StmtBase):  # pylint: disable=invalid-name
                     for child in result[4].children:
                         if isinstance(child, Name):
                             only_list.append((child.string, None))
-                        elif isinstance(child, Rename):
+                        elif isinstance(child, Rename) and not child.children[0]:
+                            # This is a Rename of a symbol rather than an operator
+                            # (which would have child.children[0] == 'OPERATOR'.
+                            # TODO #379 - support operators.
                             only_list.append(
                                 (child.children[1].string, child.children[2].string)
                             )
+                        elif isinstance(child, Generic_Spec):
+                            # For now we ignore anything other than symbol names
+                            # and this includes operators (TODO #379).
+                            pass
                         else:
                             raise InternalError(
-                                f"An Only_List can contain only Name or Rename "
-                                f"entries but found '{type(child).__name__}' when matching '{string}'"
+                                f"An Only_List can contain only Name, Rename or "
+                                f"Generic_Spec entries but found "
+                                f"'{type(child).__name__}' when matching '{string}'"
                             )
                 elif isinstance(result[4], Rename_List):
-                    renames = walk(result[4], Rename)
                     # Tuples of <local-name>, <use-name>
-                    rename_list = [
-                        (rename.children[1].string, rename.children[2].string)
-                        for rename in renames
-                    ]
+                    rename_list = []
+                    for rename in walk(result[4], Rename):
+                        # For now we exclude any operators in the Rename_List
+                        # (these have rename.children[0] == 'OPERATOR').
+                        # TODO #379.
+                        if rename.children[0] is None:
+                            rename_list.append(
+                                (rename.children[1].string, rename.children[2].string)
+                            )
 
                 table.add_use_symbols(str(result[2]), only_list, rename_list)
 
@@ -10335,32 +10350,32 @@ class Use_Stmt(StmtBase):  # pylint: disable=invalid-name
         line = string.strip()
         # Incorrect 'USE' statement or line too short
         if line[:3].upper() != "USE":
-            return
+            return None
         line = line[3:]
         # Empty string after 'USE'
         if not line:
-            return
+            return None
         # No separation between 'USE' statement and its specifiers
         if line[0].isalnum():
-            return
+            return None
         line = line.lstrip()
-        i = line.find("::")
+        idx = line.find("::")
         nature = None
         dcolon = None
-        if i != -1:
+        if idx != -1:
             # The nature of the module ("intrinsic" or
             # "non-intrinsic") is specified
             dcolon = "::"
             if line.startswith(","):
-                line_nat = line[1:i].strip()
+                line_nat = line[1:idx].strip()
                 # Missing Module_Nature between ',' and '::'
                 if not line_nat:
-                    return
+                    return None
                 nature = Module_Nature(line_nat)
-            line = line[i + 2 :].lstrip()
+            line = line[idx + 2 :].lstrip()
             # No Module_Name after 'USE, Module_Nature ::'
             if not line:
-                return
+                return None
         else:
             # Check for missing '::' after Module_Nature
             items = re.findall(r"[\w']+", line)
@@ -10379,22 +10394,22 @@ class Use_Stmt(StmtBase):  # pylint: disable=invalid-name
         name = line[:position].rstrip()
         # Missing Module_Name before Only_List
         if not name:
-            return
+            return None
         name = Module_Name(name)
         line = line[position + 1 :].lstrip()
         # Missing 'ONLY' specification after 'USE Module_Name,'
         if not line:
-            return
+            return None
         if line[:4].upper() == "ONLY":
             line = line[4:].lstrip()
             if not line:
                 # Expected ':' but there is nothing after the 'ONLY'
                 # specification
-                return
+                return None
             if line[0] != ":":
                 # Expected ':' but there is a different character
                 # after the 'ONLY' specification
-                return
+                return None
             line = line[1:].lstrip()
             if not line:
                 # Missing Only_List after 'USE Module_Name, ONLY:'
@@ -10467,9 +10482,18 @@ class Module_Nature(STRINGBase):  # pylint: disable=invalid-name
 
 class Rename(Base):  # R1111
     """
-    <rename> = <local-name> => <use-name>
-               | OPERATOR(<local-defined-operator>) =>
-                 OPERATOR(<use-defined-operator>)
+    Class defining Rule #R1111:
+
+    rename is local-name => use-name
+           or OPERATOR(local-defined-operator) => OPERATOR(use-defined-operator)
+
+    where:
+
+    local-defined-operator is defined-uary-op or
+                              defined-binary-op
+
+    defined-binary-op is .letter [letter] ... .
+
     """
 
     subclass_names = []
@@ -10482,23 +10506,38 @@ class Rename(Base):  # R1111
 
     @staticmethod
     def match(string):
-        s = string.split("=>", 1)
-        if len(s) != 2:
-            return
-        lhs, rhs = s[0].rstrip(), s[1].lstrip()
+        """
+        :param str string: the string to attempt to match.
+
+        :returns: three tuple containing description, local name, remote name.
+        :rtype: Optional[
+                    Tuple[Optional[str],
+                          :py:class:`fparser.two.Fortran2003.Local_Name` |
+                          :py:class:`fparser.two.Fortran2003.Local_Defined_Operator`,
+                          :py:class:`fparser.two.Fortran2003.Use_Name` |
+                          :py:class:`fparser.two.Fortran2003.Use_Defined_Operator`]]
+        """
+        parts = string.split("=>", 1)
+        if len(parts) != 2:
+            return None
+        lhs, rhs = parts[0].rstrip(), parts[1].lstrip()
         if not lhs or not rhs:
-            return
+            return None
         if lhs[:8].upper() == "OPERATOR" and rhs[:8].upper() == "OPERATOR":
             tmp = lhs[8:].lstrip()
-            r = rhs[8:].lstrip()
-            if tmp and r and tmp[0] + tmp[-1] == "()":
-                if r[0] + r[-1] != "()":
-                    return
+            rhs_op = rhs[8:].lstrip()
+            if tmp and rhs_op and tmp[0] + tmp[-1] == "()":
+                if rhs_op[0] + rhs_op[-1] != "()":
+                    return None
                 tmp = tmp[1:-1].strip()
-                r = r[1:-1].strip()
-                if not tmp or not r:
+                rhs_op = rhs_op[1:-1].strip()
+                if not tmp or not rhs_op:
                     return
-                return "OPERATOR", Local_Defined_Operator(tmp), Use_Defined_Operator(r)
+                return (
+                    "OPERATOR",
+                    Local_Defined_Operator(tmp),
+                    Use_Defined_Operator(rhs_op),
+                )
         return None, Local_Name(lhs), Use_Name(rhs)
 
     def tostr(self):

--- a/src/fparser/two/Fortran2003.py
+++ b/src/fparser/two/Fortran2003.py
@@ -10526,13 +10526,13 @@ class Rename(Base):  # R1111
         if lhs[:8].upper() == "OPERATOR" and rhs[:8].upper() == "OPERATOR":
             tmp = lhs[8:].lstrip()
             rhs_op = rhs[8:].lstrip()
-            if tmp and rhs_op and tmp[0] + tmp[-1] == "()":
-                if rhs_op[0] + rhs_op[-1] != "()":
+            if tmp and rhs_op and tmp[0] == "(" and tmp[-1] == ")":
+                if rhs_op[0] != "(" or rhs_op[-1] != ")":
                     return None
                 tmp = tmp[1:-1].strip()
                 rhs_op = rhs_op[1:-1].strip()
                 if not tmp or not rhs_op:
-                    return
+                    return None
                 return (
                     "OPERATOR",
                     Local_Defined_Operator(tmp),
@@ -10541,13 +10541,17 @@ class Rename(Base):  # R1111
         return None, Local_Name(lhs), Use_Name(rhs)
 
     def tostr(self):
+        """
+        :returns: the string representation of this Rename object.
+        :rtype: str
+        """
         if not self.items[0]:
-            return "%s => %s" % self.items[1:]
-        return "%s(%s) => %s(%s)" % (
-            self.items[0],
-            self.items[1],
-            self.items[0],
-            self.items[2],
+            # Not an operator.
+            return f"{self.children[1]} => {self.children[2]}"
+        # This represents the renaming of an Operator.
+        return (
+            f"{self.children[0]}({self.children[1]}) => "
+            f"{self.children[0]}({self.children[2]})"
         )
 
 

--- a/src/fparser/two/tests/fortran2003/test_cray_pointer_decl.py
+++ b/src/fparser/two/tests/fortran2003/test_cray_pointer_decl.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Science and Technology Facilities Council
+# Copyright (c) 2019-2022 Science and Technology Facilities Council
 
 # All rights reserved.
 
@@ -115,7 +115,7 @@ def test_internal_error2(f2003_create, monkeypatch):
         monkeypatch.setattr(ast, "items", (change, "mypointee"))
         with pytest.raises(InternalError) as excinfo:
             str(ast)
-        assert ("'Items' entry 0 should be a pointer name but it is " "empty") in str(
+        assert ("'Items' entry 0 should be a pointer name but it is empty") in str(
             excinfo.value
         )
 

--- a/src/fparser/two/tests/fortran2003/test_hollerith_item.py
+++ b/src/fparser/two/tests/fortran2003/test_hollerith_item.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Science and Technology Facilities Council
+# Copyright (c) 2019-2022 Science and Technology Facilities Council
 
 # All rights reserved.
 
@@ -117,7 +117,7 @@ def test_internal_error2(f2003_create, monkeypatch):
         monkeypatch.setattr(ast, "items", [content])
         with pytest.raises(InternalError) as excinfo:
             str(ast)
-        assert ("entry 0 should be a valid Hollerith string but it is " "empty") in str(
+        assert ("entry 0 should be a valid Hollerith string but it is empty") in str(
             excinfo.value
         )
 

--- a/src/fparser/two/tests/fortran2003/test_position_edit_desc_r1013.py
+++ b/src/fparser/two/tests/fortran2003/test_position_edit_desc_r1013.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2019 Science and Technology Facilities Council
+# Copyright (c) 2018-2022 Science and Technology Facilities Council
 
 # All rights reserved.
 
@@ -137,5 +137,5 @@ def test_tostr_invalid_2(f2003_create, monkeypatch):
     with pytest.raises(InternalError) as excinfo:
         _ = str(obj)
     assert (
-        "items[1] in Class Position_Edit_Desc method tostr() is " "empty or None"
+        "items[1] in Class Position_Edit_Desc method tostr() is empty or None"
     ) in str(excinfo.value)

--- a/src/fparser/two/tests/fortran2003/test_rename_r1111.py
+++ b/src/fparser/two/tests/fortran2003/test_rename_r1111.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2022 Science and Technology Facilities Council.
+
+# All rights reserved.
+
+# Modifications made as part of the fparser project are distributed
+# under the following license:
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Test Fortran 2003 rule R1111 : This file tests the support for the
+Rename class.
+
+"""
+
+from fparser.two.Fortran2003 import Rename
+
+
+def test_rename():
+    """
+    Check basic functionality of the Rename class.
+    """
+    tcls = Rename
+    obj = tcls("a=>b")
+    assert isinstance(obj, tcls), repr(obj)
+    assert str(obj) == "a => b"
+
+    obj = tcls("operator(.foo.)=>operator(.bar.)")
+    assert isinstance(obj, tcls), repr(obj)
+    assert str(obj) == "OPERATOR(.FOO.) => OPERATOR(.BAR.)"
+
+    obj = tcls("operator_1=>operator_2")
+    assert isinstance(obj, tcls), repr(obj)
+    assert str(obj) == "operator_1 => operator_2"
+
+
+def test_rename_nomatch():
+    """
+    Check that various syntax errors result in no match.
+    """
+    assert Rename.match("operator(.foo.) = operator(.bar.)") is None
+    assert Rename.match("operator(.foo.) => ") is None
+    assert Rename.match("operator(.foo.) => operator_1") is None
+    assert Rename.match("operator() => operator(.bar.)") is None

--- a/src/fparser/two/tests/fortran2003/test_rename_r1111.py
+++ b/src/fparser/two/tests/fortran2003/test_rename_r1111.py
@@ -53,7 +53,7 @@ def test_rename():
     obj = tcls("operator(.foo.)=>operator(.bar.)")
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == "OPERATOR(.FOO.) => OPERATOR(.BAR.)"
-    assert obj.children[0] == 'OPERATOR'
+    assert obj.children[0] == "OPERATOR"
 
     obj = tcls("operator_1=>operator_2")
     assert isinstance(obj, tcls), repr(obj)

--- a/src/fparser/two/tests/fortran2003/test_rename_r1111.py
+++ b/src/fparser/two/tests/fortran2003/test_rename_r1111.py
@@ -48,14 +48,17 @@ def test_rename():
     obj = tcls("a=>b")
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == "a => b"
+    assert obj.children[0] is None
 
     obj = tcls("operator(.foo.)=>operator(.bar.)")
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == "OPERATOR(.FOO.) => OPERATOR(.BAR.)"
+    assert obj.children[0] == 'OPERATOR'
 
     obj = tcls("operator_1=>operator_2")
     assert isinstance(obj, tcls), repr(obj)
     assert str(obj) == "operator_1 => operator_2"
+    assert obj.children[0] is None
 
 
 def test_rename_nomatch():

--- a/src/fparser/two/tests/fortran2003/test_usestmt_r1109.py
+++ b/src/fparser/two/tests/fortran2003/test_usestmt_r1109.py
@@ -369,9 +369,7 @@ def test_use_internal_error2():
         ast.items = (None, None, content, None, None)
         with pytest.raises(InternalError) as excinfo:
             str(ast)
-        assert "entry 2 should be a module name but it is " "empty" in str(
-            excinfo.value
-        )
+        assert "entry 2 should be a module name but it is empty" in str(excinfo.value)
 
 
 def test_use_internal_error3():

--- a/src/fparser/two/tests/fortran2003/test_usestmt_r1109.py
+++ b/src/fparser/two/tests/fortran2003/test_usestmt_r1109.py
@@ -43,13 +43,23 @@ from fparser.two.Fortran2003 import Use_Stmt
 from fparser.two.symbol_table import SYMBOL_TABLES, ModuleUse
 from fparser.two.utils import NoMatchError, InternalError
 
+
+@pytest.fixture(autouse=True)
+@pytest.mark.usefixtures("f2003_create")
+def use_f2003():
+    """
+    A pytest fixture that just sets things up so that the f2003_create
+    fixture is used automatically for every test in this file.
+    """
+
+
 # match() use ...
 
 
 # match() 'use x'. Use both string and reader input here, but from
 # here on we will just use string input as that is what is passed to
 # the match() method
-def test_use(f2003_create):
+def test_use():
     """Check that a basic use is parsed correctly. Input separately as a
     string and as a reader object
 
@@ -68,7 +78,7 @@ def test_use(f2003_create):
 
 
 # match() 'use :: x'
-def test_use_colons(f2003_create):
+def test_use_colons():
     """Check that a basic use with '::' is parsed correctly."""
     line = "use :: my_model"
     ast = Use_Stmt(line)
@@ -77,7 +87,7 @@ def test_use_colons(f2003_create):
 
 
 # match() 'use, nature :: x'
-def test_use_nature(f2003_create):
+def test_use_nature():
     """Check that a use with a 'nature' specification is parsed correctly."""
     line = "use, intrinsic :: my_model"
     ast = Use_Stmt(line)
@@ -88,7 +98,7 @@ def test_use_nature(f2003_create):
 
 
 # match() 'use x, rename'
-@pytest.mark.usefixtures("f2003_create", "fake_symbol_table")
+@pytest.mark.usefixtures("fake_symbol_table")
 def test_use_rename():
     """Check that a use with a rename clause is parsed correctly."""
     line = "use my_module, new_name=>name"
@@ -108,7 +118,6 @@ def test_use_rename():
     assert use._local_to_module_map["new_name"] == "name"
 
 
-@pytest.mark.usefixtures("f2003_create")
 def test_use_operator_rename():
     """
     Check that a use with a rename clause for an operator is parsed correctly.
@@ -131,7 +140,7 @@ def test_use_operator_rename():
 
 
 # match() 'use x, only: y'
-def test_use_only(f2003_create):
+def test_use_only():
     """Check that a use statement is parsed correctly when there is an
     only clause. Test both with and without a scoping region.
 
@@ -156,7 +165,7 @@ def test_use_only(f2003_create):
 
 
 # match() 'use x, only:'
-def test_use_only_empty(f2003_create):
+def test_use_only_empty():
     """Check that a use statement is parsed correctly when there is an
     only clause without any content. Test both with and without a scoping region.
 
@@ -178,7 +187,7 @@ def test_use_only_empty(f2003_create):
 
 
 # match() 'use x, only: b => c'
-def test_use_only_plus_rename(f2003_create):
+def test_use_only_plus_rename():
     """Check that a use statement with an only clause and some variable
     renaming is parsed correctly.
 
@@ -205,16 +214,17 @@ def test_use_only_plus_rename(f2003_create):
 
 
 # match() 'use x, only: operator(-)'
-def test_use_only_operator(f2003_create):
+def test_use_only_operator():
     """
     Check that a 'use, only' that imports an operator is parsed correctly.
 
     """
-    line = "use my_mod, only: operator(-)"
+    line = "use my_mod, only: operator(-), operator(.yes.)"
     ast = Use_Stmt(line)
     assert repr(ast) == (
         "Use_Stmt(None, None, Name('my_mod'), ', ONLY:', Only_List(',', "
-        "(Generic_Spec('OPERATOR', Extended_Intrinsic_Op('-')),)))"
+        "(Generic_Spec('OPERATOR', Extended_Intrinsic_Op('-')),"
+        " Generic_Spec('OPERATOR', Defined_Op('.YES.')))))"
     )
     # Repeat when there is a scoping region.
     SYMBOL_TABLES.enter_scope("test_scope")
@@ -227,27 +237,41 @@ def test_use_only_operator(f2003_create):
     SYMBOL_TABLES.exit_scope()
 
 
-def test_use_only_renamed_operator(f2003_create):
+@pytest.mark.parametrize("lhs, rhs", [("-", "+"), (".in.", ".out.")])
+def test_use_only_renamed_operator(lhs, rhs):
     """
     Check that a 'use, only' that imports and locally renames an operator is
-    correctly parsed.
+    correctly parsed. We test both for an extended intrinsic operator and a
+    defined operator.
 
     """
-    line = "use my_mod, only: operator(-) => operator(+)"
+    line = f"use my_mod, only: operator({lhs}) => operator({rhs})"
     ast = Use_Stmt(line)
-    assert repr(ast) == (
-        "Use_Stmt(None, None, Name('my_mod'), ', ONLY:', Only_List(',', "
-        "(Generic_Spec('OPERATOR', Extended_Intrinsic_Op('-) => "
-        "operator(+')),)))"
-    )
+    if lhs == "-":
+        assert repr(ast) == (
+            "Use_Stmt(None, None, Name('my_mod'), ', ONLY:', Only_List(',', "
+            "(Generic_Spec('OPERATOR', Extended_Intrinsic_Op('-) => "
+            "operator(+')),)))"
+        )
+    else:
+        assert repr(ast) == (
+            "Use_Stmt(None, None, Name('my_mod'), ', ONLY:', Only_List(',', "
+            "(Rename('OPERATOR', Defined_Op('.IN.'), Defined_Op('.OUT.')),)))"
+        )
+
     # Repeat when there is a scoping region.
     SYMBOL_TABLES.enter_scope("test_scope")
     ast = Use_Stmt(line)
+    table = SYMBOL_TABLES.current_scope
+    use = table._modules["my_mod"]
+    # Operators are not currently captured in the symbol table.
+    # TODO #379.
+    assert use.only_list == []
     SYMBOL_TABLES.exit_scope()
 
 
 # match() '  use  ,  nature  ::  x  ,  name=>new_name'
-def test_use_spaces_1(f2003_create):
+def test_use_spaces_1():
     """Check that a use statement with spaces works correctly with
     renaming.
 
@@ -262,7 +286,7 @@ def test_use_spaces_1(f2003_create):
 
 
 # match() '  use  ,  nature  ::  x  ,  only  :  name'
-def test_use_spaces_2(f2003_create):
+def test_use_spaces_2():
     """Check that a use statement with spaces works correctly with an only
     clause.
 
@@ -277,7 +301,7 @@ def test_use_spaces_2(f2003_create):
 
 
 # match() mixed case
-def test_use_mixed_case(f2003_create):
+def test_use_mixed_case():
     """Check that a use statement with mixed case keywords ('use' and
     'only') works as expected.
 
@@ -294,7 +318,7 @@ def test_use_mixed_case(f2003_create):
 # match() Syntax errors
 
 
-def test_syntaxerror(f2003_create):
+def test_syntaxerror():
     """Test that NoMatchError is raised for various syntax errors."""
     for line in [
         "us",
@@ -314,13 +338,13 @@ def test_syntaxerror(f2003_create):
     ]:
         with pytest.raises(NoMatchError) as excinfo:
             _ = Use_Stmt(line)
-        assert "Use_Stmt: '{0}'".format(line) in str(excinfo.value)
+        assert f"Use_Stmt: '{line}'" in str(excinfo.value)
 
 
 # match() Internal errors
 
 
-def test_use_internal_error1(f2003_create):
+def test_use_internal_error1():
     """Check that an internal error is raised if the length of the Items
     list is not 5 as the str() method assumes that it is.
 
@@ -333,7 +357,7 @@ def test_use_internal_error1(f2003_create):
     assert "should be of size 5 but found '4'" in str(excinfo.value)
 
 
-def test_use_internal_error2(f2003_create):
+def test_use_internal_error2():
     """Check that an internal error is raised if the module name (entry 2
     of Items) is empty or None as the str() method assumes that it is
     a string with content.
@@ -345,12 +369,12 @@ def test_use_internal_error2(f2003_create):
         ast.items = (None, None, content, None, None)
         with pytest.raises(InternalError) as excinfo:
             str(ast)
-        assert ("entry 2 should be a module name but it is " "empty") in str(
+        assert "entry 2 should be a module name but it is " "empty" in str(
             excinfo.value
         )
 
 
-def test_use_internal_error3(f2003_create):
+def test_use_internal_error3():
     """Check that an internal error is raised if entry 3 of Items is
     'None' as the str() method assumes it is a (potentially empty)
     string.
@@ -364,7 +388,7 @@ def test_use_internal_error3(f2003_create):
     assert "entry 3 should be a string but found 'None'" in str(excinfo.value)
 
 
-@pytest.mark.usefixtures("f2003_create", "fake_symbol_table")
+@pytest.mark.usefixtures("fake_symbol_table")
 def test_use_internal_error_only_list(monkeypatch):
     """Check that an internal error is raised if an Only_List contains an
     unexpected entry.

--- a/src/fparser/two/tests/test_fortran2003.py
+++ b/src/fparser/two/tests/test_fortran2003.py
@@ -2925,18 +2925,6 @@ def test_module_nature():
     assert "Module_Nature: 'other_nature'" in str(excinfo.value)
 
 
-def test_rename():  # R1111
-
-    tcls = Rename
-    obj = tcls("a=>b")
-    assert isinstance(obj, tcls), repr(obj)
-    assert str(obj) == "a => b"
-
-    obj = tcls("operator(.foo.)=>operator(.bar.)")
-    assert isinstance(obj, tcls), repr(obj)
-    assert str(obj) == "OPERATOR(.FOO.) => OPERATOR(.BAR.)"
-
-
 @pytest.mark.xfail(reason="Match fails with multiple spaces, see issue #197")
 def test_block_data():  # R1116
 


### PR DESCRIPTION
This is a towards since it just fixes the crash in the symbol table. It does not attempt to extend the symbol table to support operators.