### PR TITLE
(Closes #412) fix reader for include files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ Modifications by (in alphabetical order):
 * P. Vitt, University of Siegen, Germany
 * A. Voysey, UK Met Office
 
-15/05/2023 PR #415 for #165. Bug fix for spurious matching of 'NAMELIST' in
-           certain contexts.
+16/05/2023 PR #414 for #412. Bug fix for disappearing line when parsing
+           include files.
+
+15/05/2023 PR #415 for #165. Bug fix for code aborting when trying to match
+           'NAMELIST' in certain contexts.
 
 15/05/2023 PR #408 for #403. Add support for the F2008 DO CONCURRENT.
 

--- a/src/fparser/common/readfortran.py
+++ b/src/fparser/common/readfortran.py
@@ -747,8 +747,10 @@ class FortranReaderBase:
     def put_item(self, item):
         """Insert item into FIFO buffer of 'innermost' reader object.
 
-        :param item:
-        :type item:
+        :param item: the item to insert into the FIFO.
+        :type item: :py:class:`fparser.common.readfortran.Line` | \
+                    :py:class:`fparser.common.readfortran.MultiLine` | \
+                    :py:class:`fparser.common.readfortran.Comment`
         """
         if self.reader:
             # We are reading an INCLUDE file so put this item in the FIFO
@@ -776,7 +778,7 @@ class FortranReaderBase:
         value.
 
         :returns: the next line item. This can be from a local fifo \
-        buffer, from an include reader or from this reader.
+                  buffer, from an include reader or from this reader.
         :rtype: py:class:`fparser.common.readfortran.Line`
 
         :raises StopIteration: if no more lines are found.

--- a/src/fparser/common/readfortran.py
+++ b/src/fparser/common/readfortran.py
@@ -745,8 +745,17 @@ class FortranReaderBase:
         return item
 
     def put_item(self, item):
-        """Insert item to FIFO item buffer."""
-        self.fifo_item.insert(0, item)
+        """Insert item into FIFO buffer of 'innermost' reader object.
+
+        :param item:
+        :type item:
+        """
+        if self.reader:
+            # We are reading an INCLUDE file so put this item in the FIFO
+            # of the corresponding reader.
+            self.reader.put_item(item)
+        else:
+            self.fifo_item.insert(0, item)
 
     # Iterator methods:
 
@@ -780,26 +789,12 @@ class FortranReaderBase:
             if self.reader is not None:
                 # inside INCLUDE statement
                 try:
-                    # Manually check to see if something has not
-                    # matched and has been placed in the fifo. We
-                    # can't use _next() as this method is associated
-                    # with the include reader (self.reader._next()),
-                    # not this reader (self._next()).
-                    item = self.fifo_item.pop(0)
-                    #if ignore_comments:
-                    #    while isinstance(item, Comment):
-                    #        item = self.fifo_item.pop(0)
-                    return item
-                except IndexError:
-                    # There is nothing in the fifo buffer.
-                    try:
-                        # Return a line from the include.
-                        return self.reader.next(ignore_comments)
-                    except StopIteration:
-                        # There is nothing left in the include
-                        # file. Setting reader to None indicates that
-                        # we should now read from the main reader.
-                        self.reader = None
+                    return self.reader.next(ignore_comments)
+                except StopIteration:
+                    # There is nothing left in the include
+                    # file. Setting reader to None indicates that
+                    # we should now read from the main reader.
+                    self.reader = None
             item = self._next(ignore_comments)
             if isinstance(item, Line) and _IS_INCLUDE_LINE(item.line):
                 # catch INCLUDE statement and create a new FortranReader

--- a/src/fparser/common/tests/test_readfortran.py
+++ b/src/fparser/common/tests/test_readfortran.py
@@ -705,6 +705,9 @@ end program my_prog
     lines = []
     while True:
         lines.append(reader.get_item())
+        # Try immediately putting the line back and then requesting it again.
+        reader.put_item(lines[-1])
+        assert reader.get_item().line == lines[-1].line
         if "var3 =" in lines[-1].line:
             # Stop reading while we're still in the INCLUDE file.
             break

--- a/src/fparser/common/tests/test_readfortran.py
+++ b/src/fparser/common/tests/test_readfortran.py
@@ -680,20 +680,41 @@ def test_put_item(ignore_comments):
         assert fifo_line == orig_line
 
 
-def test_put_item_include(ignore_comments):
+def test_put_item_include(ignore_comments, tmpdir):
     """Check that when a line that has been included via an include
     statement is consumed it can be pushed back so it can be consumed
     again. Test with and without ignoring comments.
 
     """
-    reader = FortranStringReader(FORTRAN_CODE, ignore_comments=ignore_comments)
+    _ = tmpdir.chdir()
+    cwd = str(tmpdir)
+    include_code = """
+    var1 = 1
+    var2 = 2
+    var3 = 3
+"""
+    with open(os.path.join(cwd, "my_include.h"), "w") as cfile:
+        cfile.write(include_code)
+    code = """
+program my_prog
+  integer :: var1, var2, var3
+  include 'my_include.h'
+end program my_prog
+"""
+    reader = FortranStringReader(code, ignore_comments=ignore_comments)
+    lines = []
     while True:
-        orig_line = reader.get_item()
-        if not orig_line:
+        lines.append(reader.get_item())
+        if "var3 =" in lines[-1].line:
+            # Stop reading while we're still in the INCLUDE file.
             break
-        reader.put_item(orig_line)
-        fifo_line = reader.get_item()
-        assert fifo_line == orig_line
+    # Put all the lines back in the same order that we saw them.
+    for line in reversed(lines):
+        reader.put_item(line)
+    # Check that the reader returns all those lines in the same order that
+    # we saw them originally.
+    for line in lines:
+        assert reader.get_item().line == line.line
 
 
 def test_multi_put_item(ignore_comments):

--- a/src/fparser/common/tests/test_readfortran.py
+++ b/src/fparser/common/tests/test_readfortran.py
@@ -416,7 +416,6 @@ def check_include_works(
         reader = FortranFileReader(fortran_filename, ignore_comments=ignore_comments)
         for orig_line in expected.split("\n"):
             new_line = reader.next().line
-            print(new_line+"\n====\n"+orig_line)
             assert new_line == orig_line
         with pytest.raises(StopIteration):
             reader.next()

--- a/src/fparser/common/tests/test_readfortran.py
+++ b/src/fparser/common/tests/test_readfortran.py
@@ -416,6 +416,7 @@ def check_include_works(
         reader = FortranFileReader(fortran_filename, ignore_comments=ignore_comments)
         for orig_line in expected.split("\n"):
             new_line = reader.next().line
+            print(new_line+"\n====\n"+orig_line)
             assert new_line == orig_line
         with pytest.raises(StopIteration):
             reader.next()

--- a/src/fparser/common/tests/test_readfortran.py
+++ b/src/fparser/common/tests/test_readfortran.py
@@ -706,10 +706,12 @@ end program my_prog
     while True:
         lines.append(reader.get_item())
         # Try immediately putting the line back and then requesting it again.
+        # This checks that the correct FIFO buffer is being used.
         reader.put_item(lines[-1])
         assert reader.get_item().line == lines[-1].line
         if "var3 =" in lines[-1].line:
-            # Stop reading while we're still in the INCLUDE file.
+            # Stop reading while we're still in the INCLUDE file so that we
+            # have a stack of readers when calling `put_item` below.
             break
     # Put all the lines back in the same order that we saw them.
     for line in reversed(lines):

--- a/src/fparser/two/tests/test_utils.py
+++ b/src/fparser/two/tests/test_utils.py
@@ -37,11 +37,8 @@ exception handling and ast traversal.
 
 """
 
-import os
-
 import pytest
 from fparser.api import get_reader
-from fparser.common.readfortran import FortranFileReader
 from fparser.two import Fortran2003, utils
 
 
@@ -144,30 +141,3 @@ def test_endstmtbase_match():
         require_stmt_type=True,
     )
     assert result == ("SUBROUTINE", Fortran2003.Name("sub"))
-
-
-@pytest.mark.usefixtures("f2003_create")
-def test_base_include_handling(tmpdir):
-    """Test parsing of code that involves an INCLUDE. This is beyond what
-    is tested in test_readfortran as it exercises the mechanisms used when
-    a match fails and content is given back to the reader."""
-    fortran_code = (
-        "module include_test\n  include 'test_include.h'\nend module include_test"
-    )
-    include_code = (
-        "interface mpi_sizeof\n"
-        "subroutine simple()\n"
-        "end subroutine simple\n"
-        "end interface mpi_sizeof"
-    )
-    with open(os.path.join(tmpdir, "test_prog.f90"), "w", encoding="utf-8") as cfile:
-        cfile.write(fortran_code)
-    with open(os.path.join(tmpdir, "test_include.h"), "w", encoding="utf-8") as cfile:
-        cfile.write(include_code)
-    reader = FortranFileReader(
-        os.path.join(tmpdir, "test_prog.f90"), include_dirs=[tmpdir]
-    )
-    prog = Fortran2003.Program(reader)
-    assert isinstance(prog, Fortran2003.Program)
-    nodes = utils.walk(prog, Fortran2003.Interface_Stmt)
-    assert len(nodes) == 1

--- a/src/fparser/two/tests/test_utils.py
+++ b/src/fparser/two/tests/test_utils.py
@@ -37,8 +37,11 @@ exception handling and ast traversal.
 
 """
 
+import os
+
 import pytest
 from fparser.api import get_reader
+from fparser.common.readfortran import FortranFileReader
 from fparser.two import Fortran2003, utils
 
 
@@ -141,3 +144,30 @@ def test_endstmtbase_match():
         require_stmt_type=True,
     )
     assert result == ("SUBROUTINE", Fortran2003.Name("sub"))
+
+
+@pytest.mark.usefixtures("f2003_create")
+def test_base_include_handling(tmpdir):
+    """Test parsing of code that involves an INCLUDE. This is beyond what
+    is tested in test_readfortran as it exercises the mechanisms used when
+    a match fails and content is given back to the reader."""
+    fortran_code = (
+        "module include_test\n  include 'test_include.h'\nend module include_test"
+    )
+    include_code = (
+        "interface mpi_sizeof\n"
+        "subroutine simple()\n"
+        "end subroutine simple\n"
+        "end interface mpi_sizeof"
+    )
+    with open(os.path.join(tmpdir, "test_prog.f90"), "w", encoding="utf-8") as cfile:
+        cfile.write(fortran_code)
+    with open(os.path.join(tmpdir, "test_include.h"), "w", encoding="utf-8") as cfile:
+        cfile.write(include_code)
+    reader = FortranFileReader(
+        os.path.join(tmpdir, "test_prog.f90"), include_dirs=[tmpdir]
+    )
+    prog = Fortran2003.Program(reader)
+    assert isinstance(prog, Fortran2003.Program)
+    nodes = utils.walk(prog, Fortran2003.Interface_Stmt)
+    assert len(nodes) == 1


### PR DESCRIPTION
Currently the reader reverses the lines it returns for an include file. This happens if a match fails and read lines are pushed into the FIFO. This PR is a small fix which just ensures that such lines are pushed into the FIFO of the current reader object rather than the top-level one.