### PR TITLE
#454 Create file in pytest's tmpdir, not in /tmp.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Modifications by (in alphabetical order):
 * P. Vitt, University of Siegen, Germany
 * A. Voysey, UK Met Office
 
+28/11/2024 PR #455 for #454. Fixes a few tests to use the tmpdir fixture
+           rather than writing directly to /tmp.
+
+## Release 0.2.0 (26/11/2024) ##
+
 25/11/2024 PR #453 extension of base node types to allow the parse tree to be
            deepcopied and pickled.
 

--- a/src/fparser/common/tests/test_readfortran.py
+++ b/src/fparser/common/tests/test_readfortran.py
@@ -44,7 +44,6 @@ Test battery associated with fparser.common.readfortran package.
 
 import io
 import os.path
-import tempfile
 import pytest
 
 from fparser.common.readfortran import (
@@ -787,12 +786,11 @@ FULL_FREE_EXPECTED = [
 ##############################################################################
 
 
-def test_filename_reader():
+def test_filename_reader(tmpdir):
     """
     Tests that a Fortran source file can be read given its filename.
     """
-    handle, filename = tempfile.mkstemp(suffix=".f90", text=True)
-    os.close(handle)
+    filename = f"{tmpdir}/out.f90"
     try:
         with io.open(filename, mode="w", encoding="UTF-8") as source_file:
             source_file.write(FULL_FREE_SOURCE)
@@ -811,12 +809,11 @@ def test_filename_reader():
 ##############################################################################
 
 
-def test_file_reader():
+def test_file_reader(tmpdir):
     """
     Tests that a Fortran source file can be read given a file object of it.
     """
-    handle, filename = tempfile.mkstemp(suffix=".f90", text=True)
-    os.close(handle)
+    filename = f"{tmpdir}/out.f90"
     try:
         with io.open(filename, mode="w", encoding="UTF-8") as source_file:
             source_file.write(FULL_FREE_SOURCE)
@@ -833,12 +830,11 @@ def test_file_reader():
         raise
 
 
-def test_none_in_fifo(log):
+def test_none_in_fifo(tmpdir, log):
     """Check that a None entry in the reader FIFO buffer is handled
     correctly."""
     log.reset()
-    handle, filename = tempfile.mkstemp(suffix=".f90", text=True)
-    os.close(handle)
+    filename = f"{tmpdir}/out.f90"
 
     with io.open(filename, mode="w", encoding="UTF-8") as source_file:
         source_file.write(FULL_FREE_SOURCE)
@@ -913,7 +909,7 @@ def test_reader_ignore_encoding(reader_cls, tmp_path):
     assert reader2.format == FortranFormat(False, True)
 
 
-def test_inherited_f77():
+def test_inherited_f77(tmpdir):
     """
     A grab bag of functional tests inherited from readfortran.py.
     """
@@ -948,8 +944,8 @@ a    'g
         assert str(item) == stack.pop(0)
 
     # Reading from file
-    handle, filename = tempfile.mkstemp(suffix=".f", text=True)
-    os.close(handle)
+    filename = f"{tmpdir}/out.f"
+
     with open(filename, "w") as fortran_file:
         print(string_f77, file=fortran_file)
 

--- a/src/fparser/common/tests/test_sourceinfo.py
+++ b/src/fparser/common/tests/test_sourceinfo.py
@@ -35,6 +35,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ##############################################################################
 # Modified M.Hambley, UK Met Office
+# Modified by J. Henrichs, Bureau of Meteorology
 ##############################################################################
 """
 Test battery associated with fparser.sourceinfo package.
@@ -315,7 +316,7 @@ def extension(request):
 ##############################################################################
 
 
-def test_get_source_info_filename(extension, header, content):
+def test_get_source_info_filename(tmpdir, extension, header, content):
     # pylint: disable=redefined-outer-name
     """
     Tests that source format is correctly identified when read from a file.
@@ -326,8 +327,7 @@ def test_get_source_info_filename(extension, header, content):
     if content[0] is not None:
         full_source += content[0]
 
-    source_file, filename = tempfile.mkstemp(suffix=extension[0], text=True)
-    os.close(source_file)
+    filename = f"{tmpdir}/out{extension[0]}"
 
     with open(filename, "w") as source_file:
         print(full_source, file=source_file)


### PR DESCRIPTION
Use pytest tmpdir (which is cleaned up automatically), instead of /tmp for temporary files (over 220 files per test run). Fixes #454.