### PR TITLE
458 make public improvements

### DIFF
--- a/example/make_public.py
+++ b/example/make_public.py
@@ -3,7 +3,7 @@
 # -----------------------------------------------------------------------------
 # BSD 3-Clause License
 #
-# Copyright (c) 2024, Science and Technology Facilities Council.
+# Copyright (c) 2024-2025, Science and Technology Facilities Council.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -64,7 +64,9 @@ def remove_private(filename):
     """Simple function that removes all private and protected declarations.
     :param str filename: the file in which to remove private and protected
     """
-    reader = FortranFileReader(filename)
+    # Do not filter out comments, since this would remove UM-style
+    # 'depends on' comments for dependencies that are otherwise not detected.
+    reader = FortranFileReader(filename, ignore_comments=False)
     parser = ParserFactory().create(std="f2008")
     parse_tree = parser(reader)
     # A useful print to see the actual rules

--- a/example/test_files/make_public_correct.f90
+++ b/example/test_files/make_public_correct.f90
@@ -1,15 +1,30 @@
 MODULE a_mod
+
+  ! Access_Stmt
+
+  ! Attr_Spec with 0 and 1 additional attribute
   REAL :: planet_radius = 123
   REAL, PARAMETER :: planet_radius_constant = 123
+
   LOGICAL :: public_protected = .FALSE.
   LOGICAL :: only_protected = .FALSE.
   LOGICAL :: private_protected = .FALSE.
+
+  ! Access_stmt
   PUBLIC :: public_protected
+  ! Protected_Stmt
+  ! Access_stmt
+
   TYPE :: my_type
+    ! Private_Components_Stmt
     INTEGER :: a, b
     CONTAINS
+
   END TYPE my_type
+
+  ! Access_Spec
   TYPE(my_type), PUBLIC :: my_var
+
   CONTAINS
   SUBROUTINE sub_a
   END SUBROUTINE sub_a

--- a/src/fparser/common/readfortran.py
+++ b/src/fparser/common/readfortran.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Modified work Copyright (c) 2017-2024 Science and Technology
+# Modified work Copyright (c) 2017-2025 Science and Technology
 # Facilities Council.
 # Original work Copyright (c) 1999-2008 Pearu Peterson
 
@@ -553,7 +553,10 @@ class FortranReaderBase:
                  `sourceinfo.get_source_info()`
     :type mode: :py:class:`fparser.common.sourceinfo.Format`
     :param bool isstrict: whether we are strictly enforcing fixed format.
-    :param bool ignore_comments: whether or not to discard comments.
+    :param bool ignore_comments: whether or not to discard comments. If
+        comments are not ignored, they will be added as special Comment node
+        to the tree, and will therefore also be added to the output Fortran
+        source code.
     :param Optional[bool] include_omp_conditional_lines: whether or not the
         content of a line with an OMP sentinel is parsed or not. Default is
         False (in which case it is treated as a Comment).
@@ -1633,7 +1636,10 @@ class FortranFileReader(FortranReaderBase):
     :param list include_dirs: Directories in which to look for inclusions.
     :param list source_only: Fortran source files to search for modules
         required by "use" statements.
-    :param bool ignore_comments: Whether or not to ignore comments
+    :param bool ignore_comments: whether or not to discard comments. If
+        comments are not ignored, they will be added as special Comment node
+        to the tree, and will therefore also be added to the output Fortran
+        source code.
     :param Optional[bool] ignore_encoding: whether or not to ignore
         Python-style encoding information (e.g. "-*- fortran -*-") when
         attempting to determine the format of the file. Default is True.
@@ -1714,7 +1720,10 @@ class FortranStringReader(FortranReaderBase):
     :param list include_dirs: List of dirs to search for include files
     :param list source_only: Fortran source files to search for modules
         required by "use" statements.
-    :param bool ignore_comments: Whether or not to ignore comments
+    :param bool ignore_comments: whether or not to discard comments. If
+        comments are not ignored, they will be added as special Comment node
+        to the tree, and will therefore also be added to the output Fortran
+        source code.
     :param Optional[bool] ignore_encoding: whether or not to ignore
         Python-style encoding information (e.g. "-*- fortran -*-") when
         attempting to determine the format of the source. Default is True.


### PR DESCRIPTION
Addresses #458:
1. Leave comments in the code (to support UM-style "depends on" comments)
2. Add example code of how to leave some definitions unchanged, used to leave "DrHook variables" like `ModuleName` private (these can cause compilation failures if wildcard imports are used, because a module then ends up with two conflicting definitions). The code does not change anything atm (i.e. the list of names to ignore is empty), so no change unless a user changes this definition. We do this in our LFRic-build environment for example.
3. I also added more comments to the 'ignore_comments` docstring. Admittedly, it was actually clear and I was overthinking things, but I guess making this explicit can't hurt.
