### PR TITLE
499 avoid exponential loop handling

### DIFF
--- a/src/fparser/two/C99Preprocessor.py
+++ b/src/fparser/two/C99Preprocessor.py
@@ -32,7 +32,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""C99 Preprocessor Syntax Rules."""
+"""C99 Preprocessor Syntax Rules. It also supports linemarker statements
+(which are technically not preprocessor directives, but are very close
+in their syntax, i.e. starting with `#`)
+
+"""
 
 # Author: Balthasar Reuter <balthasar.reuter@ecmwf.int>
 # Based on previous work by Martin Schlipf (https://github.com/martin-schlipf)
@@ -658,11 +662,11 @@ class Cpp_Linemarker_Stmt(WORDClsBase):  # Linemarker
     """
 
     subclass_names = []
-    use_names = ["<digit-string>", "Cpp_Pp_Tokens"]
+    use_names = ["Cpp_Pp_Tokens"]
 
-    _pattern = pattern.Pattern("<linemarker>",
-                               r"^\s*#",
-                               value="#")
+    # The match method will check that it is a valid linemarker, i.e.
+    # it has a line number, and file name in double quotes.
+    _pattern = pattern.Pattern("<linemarker>", r"^\s*#", value="#")
 
     @staticmethod
     def match(string):
@@ -679,6 +683,14 @@ class Cpp_Linemarker_Stmt(WORDClsBase):  # Linemarker
         """
         if not string:
             return None
+
+        # We can't fully rely on WORDClsBase, since it can't easily
+        # test if there is a line number following (it returns
+        # `value` for a match, but can't insert the matched line number
+        # in this value).
+        if not re.match(r"^\s*#\s+[0-9]+\s+\".*\"", string):
+            return
+
         return WORDClsBase.match(
             Cpp_Linemarker_Stmt._pattern,
             Cpp_Pp_Tokens,

--- a/src/fparser/two/C99Preprocessor.py
+++ b/src/fparser/two/C99Preprocessor.py
@@ -666,7 +666,7 @@ class Cpp_Linemarker_Stmt(WORDClsBase):  # Linemarker
 
     # The match method will check that it is a valid linemarker, i.e.
     # it has a line number, and file name in double quotes.
-    _pattern = pattern.Pattern("<linemarker>", r"^\s*#", value="#")
+    _pattern = pattern.Pattern("<linemarker>", r"^\s*#\s+\d+\s+\".*\".*$")
 
     @staticmethod
     def match(string):
@@ -684,27 +684,23 @@ class Cpp_Linemarker_Stmt(WORDClsBase):  # Linemarker
         if not string:
             return None
 
-        # We can't fully rely on WORDClsBase, since it can't easily
-        # test if there is a line number following (it returns
-        # `value` for a match, but can't insert the matched line number
-        # in this value).
-        if not re.match(r"^\s*#\s+[0-9]+\s+\".*\"", string):
-            return
-
         return WORDClsBase.match(
             Cpp_Linemarker_Stmt._pattern,
             Cpp_Pp_Tokens,
             string,
             colons=False,
-            require_cls=True,
+            require_cls=False,
         )
 
     def tostr(self):
         """
+        Returns the line marker as string. Note that fparser accepts
+        spaces before the `#`, but it should remove the spaces, hence
+        we lstrip the result
         :return: this linemarker as a string.
         :rtype: str
         """
-        return "{0} {1}".format(*self.items)
+        return self.items[0].lstrip()
 
 
 class Cpp_Error_Stmt(WORDClsBase):  # 6.10.5 Error directive

--- a/src/fparser/two/C99Preprocessor.py
+++ b/src/fparser/two/C99Preprocessor.py
@@ -57,6 +57,7 @@ CPP_CLASS_NAMES = [
     "Cpp_Macro_Stmt",
     "Cpp_Undef_Stmt",
     "Cpp_Line_Stmt",
+    "Cpp_Linemarker_Stmt",
     "Cpp_Error_Stmt",
     "Cpp_Warning_Stmt",
     "Cpp_Null_Stmt",
@@ -644,6 +645,51 @@ class Cpp_Line_Stmt(WORDClsBase):  # 6.10.4 Line control
     def tostr(self):
         """
         :return: this line-stmt as a string.
+        :rtype: str
+        """
+        return "{0} {1}".format(*self.items)
+
+
+class Cpp_Linemarker_Stmt(WORDClsBase):  # Linemarker
+    """
+    Linemarker
+
+    linemarker-stmt is # digit-sequence [ "s-char-sequence" ] [digit ...]
+    """
+
+    subclass_names = []
+    use_names = ["<digit-string>", "Cpp_Pp_Tokens"]
+
+    _pattern = pattern.Pattern("<linemarker>",
+                               r"^\s*#",
+                               value="#")
+
+    @staticmethod
+    def match(string):
+        """Implements the matching for a linemarker.
+        The right hand side of the directive is not matched any further
+        but simply kept as a string.
+
+        :param str string: the string to match with as a line statement.
+
+        :return: a tuple of size 1 with the right hand side as a string, \
+                  or `None` if there is no match.
+        :rtype: (`str`) or `NoneType`
+
+        """
+        if not string:
+            return None
+        return WORDClsBase.match(
+            Cpp_Linemarker_Stmt._pattern,
+            Cpp_Pp_Tokens,
+            string,
+            colons=False,
+            require_cls=True,
+        )
+
+    def tostr(self):
+        """
+        :return: this linemarker as a string.
         :rtype: str
         """
         return "{0} {1}".format(*self.items)

--- a/src/fparser/two/C99Preprocessor.py
+++ b/src/fparser/two/C99Preprocessor.py
@@ -658,7 +658,7 @@ class Cpp_Linemarker_Stmt(WORDClsBase):  # Linemarker
     """
     Linemarker
 
-    linemarker-stmt is # digit-sequence [ "s-char-sequence" ] [digit ...]
+    linemarker-stmt is # digit-sequence "s-char-sequence" [digit ...]
     """
 
     subclass_names = []

--- a/src/fparser/two/tests/test_c99preprocessor.py
+++ b/src/fparser/two/tests/test_c99preprocessor.py
@@ -453,15 +453,28 @@ def test_incorrect_line_stmt(line):
 
 
 @pytest.mark.usefixtures("f2003_create")
-@pytest.mark.parametrize("line_ref",
-                         [('# 123 "file"', '# 123 "file"'),
-                          ('  #     123 "file"  ', '# 123 "file"'),
-                          ('# 123 "file" 1 3', '# 123 "file" 1 3')])
-def test_linemarker_statement(line_ref):
+@pytest.mark.parametrize(
+    "line_ref",
+    [
+        ('# 123 "file"', '# 123 "file"'),
+        ('  #     123 "file"  ', '# 123 "file"'),
+        ('# 123 "file" 1 3', '# 123 "file" 1 3'),
+    ],
+)
+def test_linemarker(line_ref):
     """Test that #line is recognized"""
     line, ref = line_ref
     result = Cpp_Linemarker_Stmt(line)
     assert str(result) == ref
+
+
+@pytest.mark.usefixtures("f2003_create")
+@pytest.mark.parametrize("line", ["# abc", '# "bla"', "# 123 'wrong_quotes'"])
+def test_incorrect_linemarker(line):
+    """Test that incorrectly formed #line statements raise exception"""
+    with pytest.raises(NoMatchError) as excinfo:
+        _ = Cpp_Linemarker_Stmt(line)
+    assert "Cpp_Linemarker_Stmt: '{0}'".format(line) in str(excinfo.value)
 
 
 @pytest.mark.usefixtures("f2003_create")

--- a/src/fparser/two/tests/test_c99preprocessor.py
+++ b/src/fparser/two/tests/test_c99preprocessor.py
@@ -57,6 +57,7 @@ from fparser.two.C99Preprocessor import (
     Cpp_Macro_Identifier_List,
     Cpp_Undef_Stmt,
     Cpp_Line_Stmt,
+    Cpp_Linemarker_Stmt,
     Cpp_Error_Stmt,
     Cpp_Warning_Stmt,
     Cpp_Null_Stmt,
@@ -449,6 +450,18 @@ def test_incorrect_line_stmt(line):
     with pytest.raises(NoMatchError) as excinfo:
         _ = Cpp_Line_Stmt(line)
     assert "Cpp_Line_Stmt: '{0}'".format(line) in str(excinfo.value)
+
+
+@pytest.mark.usefixtures("f2003_create")
+@pytest.mark.parametrize("line_ref",
+                         [('# 123 "file"', '# 123 "file"'),
+                          ('  #     123 "file"  ', '# 123 "file"'),
+                          ('# 123 "file" 1 3', '# 123 "file" 1 3')])
+def test_linemarker_statement(line_ref):
+    """Test that #line is recognized"""
+    line, ref = line_ref
+    result = Cpp_Linemarker_Stmt(line)
+    assert str(result) == ref
 
 
 @pytest.mark.usefixtures("f2003_create")

--- a/src/fparser/two/tests/test_c99preprocessor.py
+++ b/src/fparser/two/tests/test_c99preprocessor.py
@@ -454,16 +454,15 @@ def test_incorrect_line_stmt(line):
 
 @pytest.mark.usefixtures("f2003_create")
 @pytest.mark.parametrize(
-    "line_ref",
+    "line, ref",
     [
         ('# 123 "file"', '# 123 "file"'),
         ('  #     123 "file"  ', '# 123 "file"'),
         ('# 123 "file" 1 3', '# 123 "file" 1 3'),
     ],
 )
-def test_linemarker(line_ref):
+def test_linemarker(line, ref):
     """Test that #line is recognized"""
-    line, ref = line_ref
     result = Cpp_Linemarker_Stmt(line)
     assert str(result) == ref
 

--- a/src/fparser/two/tests/test_c99preprocessor.py
+++ b/src/fparser/two/tests/test_c99preprocessor.py
@@ -457,7 +457,7 @@ def test_incorrect_line_stmt(line):
     "line, ref",
     [
         ('# 123 "file"', '# 123 "file"'),
-        ('  #     123 "file"  ', '# 123 "file"'),
+        ('  #     123 "file"', '#     123 "file"'),
         ('# 123 "file" 1 3', '# 123 "file" 1 3'),
     ],
 )

--- a/src/fparser/two/utils.py
+++ b/src/fparser/two/utils.py
@@ -325,6 +325,7 @@ class DynamicImport:
             Else_If_Stmt,
             Else_Stmt,
             End_If_Stmt,
+            Label_Do_Stmt,
             Masked_Elsewhere_Stmt,
             Elsewhere_Stmt,
             End_Where_Stmt,
@@ -749,6 +750,21 @@ class BlockBase(Base):
                     # starting from the i+1'th...
                     i += 1
                     continue
+
+                from fparser.two.Fortran2003 import Continue_Stmt, End_Do, End_Do_Stmt, Label_Do_Stmt
+                if (startcls and
+                    isinstance(content[start_idx], Label_Do_Stmt) and
+                    hasattr(obj, "get_end_label") and
+                    content[start_idx].get_start_label() == obj.get_end_label()
+                    and endcls is End_Do and
+                    not isinstance(obj, (End_Do_Stmt, Continue_Stmt))):
+                    if table_name:
+                        SYMBOL_TABLES.exit_scope()
+                    obj.restore_reader(reader)
+                    for obj in reversed(content):
+                        obj.restore_reader(reader)
+                    return None
+
 
                 # We got a match for this class
                 had_match = True

--- a/src/fparser/two/utils.py
+++ b/src/fparser/two/utils.py
@@ -325,7 +325,6 @@ class DynamicImport:
             Else_If_Stmt,
             Else_Stmt,
             End_If_Stmt,
-            Label_Do_Stmt,
             Masked_Elsewhere_Stmt,
             Elsewhere_Stmt,
             End_Where_Stmt,
@@ -337,7 +336,12 @@ class DynamicImport:
             Comment,
             Include_Stmt,
             add_comments_includes_directives,
+            Continue_Stmt,
+            End_Do,
+            End_Do_Stmt,
+            Label_Do_Stmt,
         )
+
         from fparser.two import C99Preprocessor
 
         DynamicImport.Else_If_Stmt = Else_If_Stmt
@@ -357,6 +361,10 @@ class DynamicImport:
         DynamicImport.add_comments_includes_directives = (
             add_comments_includes_directives
         )
+        DynamicImport.Continue_Stmt = Continue_Stmt,
+        DynamicImport.End_Do = End_Do
+        DynamicImport.End_Do_Stmt = End_Do_Stmt
+        DynamicImport.Label_Do_Stmt = Label_Do_Stmt
 
 
 di = DynamicImport()
@@ -751,20 +759,37 @@ class BlockBase(Base):
                     i += 1
                     continue
 
-                from fparser.two.Fortran2003 import Continue_Stmt, End_Do, End_Do_Stmt, Label_Do_Stmt
-                if (startcls and
-                    isinstance(content[start_idx], Label_Do_Stmt) and
-                    hasattr(obj, "get_end_label") and
-                    content[start_idx].get_start_label() == obj.get_end_label()
-                    and endcls is End_Do and
-                    not isinstance(obj, (End_Do_Stmt, Continue_Stmt))):
+                # The grammar contains an exponential scaling behaviour for
+                # non-blocked labelled loop statements. The parser will try
+                # to find a match for a blocked do statement, but will ignore
+                # the fact that there is a non-blocking label, e.g.:
+                #     do 10 i=1, 10
+                # 10     a(i) = 1
+                # It will try to find a `10 enddo` or `10 continue` statement,
+                # ignoring the fact that the label 10 indicates that it is not
+                # a blocked loop. Full details in ticket 499.
+                # In order to avoid that, we identify if we are looking for a
+                # labelled loop which is blocked (endcls=End_Do), and have
+                # neither an `End_Do` nor a `Continue`, which has the same
+                # label: in this case we can abort looking (which will then
+                # trigger the caller to test for the next rule, which is a
+                # non-blocked loop). This breaks the exponential behaviour
+                # in case of non-blocked loops (since the parser won't look
+                # ahead till the end of the file).
+                if (startcls is di.Label_Do_Stmt and endcls is di.End_Do and
+                        hasattr(obj, "get_end_label") and
+                        (content[start_idx].get_start_label() ==
+                            obj.get_end_label()) and
+                        not isinstance(obj, (di.End_Do_Stmt, di.Continue_Stmt))):
                     if table_name:
                         SYMBOL_TABLES.exit_scope()
+                    # We need to put the just read statement back:
                     obj.restore_reader(reader)
+                    # ... and then also restore all previously read content
                     for obj in reversed(content):
                         obj.restore_reader(reader)
+                    # ... before we abort.
                     return None
-
 
                 # We got a match for this class
                 had_match = True

--- a/src/fparser/two/utils.py
+++ b/src/fparser/two/utils.py
@@ -1819,7 +1819,12 @@ class WORDClsBase(Base):
             if my_match is None:
                 return None
             line = string[len(my_match.group()) :]
-            pattern_value = keyword.value
+            # If no constant return value is defined,
+            # return the matched string
+            if keyword.value:
+                pattern_value = keyword.value
+            else:
+                pattern_value = my_match.group()
 
         if not line:
             if require_cls:


### PR DESCRIPTION
Fixes the exponential behaviour with number of non-blocked loops in one Fortran unit. This is done by detecting when searching for a blocked loop in e.g.:
```
      do 10 i=1, 10
 10     a(i) = i
```
That the statement with label 10 indicates that there is no matching `10 enddo` (or continue) statement coming, and therefore abooting earlier.

It cuts down parse time for a socrates file that was not parsed in 40 minutes(!!) down to 7 seconds.

Problem: I don't know how to test this patch. During development, the existing tests have flagged some issues I had, so the code is definitely used, and would trigger a failed test if it is really broken. But I don't really know how to test if it triggers as expected (since the function itself would return None without this patch as well ... just later)

Suggestions welcome