### PR TITLE
499 avoid exponential loop handling clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Modifications by (in alphabetical order):
 * A. Voysey, UK Met Office
 
 
+26/05/2026 PR #501 for #499. Avoid exponential loop handling for non-blocked
+           loops when labels are involved.
+
 27/04/2026 PR #504 for #503. Improve preprocessor directives parsing.
 
 ## Release 0.2.2 (19/03/2026) ##

--- a/src/fparser/two/tests/fortran2003/test_block_do_construct_r826.py
+++ b/src/fparser/two/tests/fortran2003/test_block_do_construct_r826.py
@@ -38,7 +38,7 @@
 import pytest
 from fparser.api import get_reader
 from fparser.common.readfortran import FortranStringReader
-from fparser.two.utils import FortranSyntaxError
+from fparser.two.utils import FortranSyntaxError, NoMatchError
 from fparser.two.Fortran2003 import (
     Block_Label_Do_Construct,
     Block_Nonlabel_Do_Construct,
@@ -245,3 +245,26 @@ def test_do_construct_missing_end_name(f2003_create, fake_symbol_table):
                 a = 1
             end do"""))
     assert exc_info.value.args[0].endswith("Expecting name 'name' but none given")
+
+
+@pytest.mark.usefixtures("f2003_create")
+def test_block_abort_early():
+    """Tests that a parsing a blocked do loop will abort early if it detects
+    a non-blocked loop (which avoids an exponential scaling). This is done
+    by trying to parse a non-blocked loop as Block_Label_Do_Construct,
+    and analysing the returned error message. If the parsing does not abort
+    early, the error location will be line 4 (and an empty line, indicating
+    the end of file was reached).
+    If on the other hand the abort happens early, the assignment in line
+    2 will be returned as the error, indicating that the exponential
+    behaviour is avoided.
+    """
+
+    with pytest.raises(NoMatchError) as err:
+        Block_Label_Do_Construct(get_reader("""\
+          do 12
+ 12          a = 1
+          call test()
+        """))
+    assert "at line 2" in str(err.value)
+    assert "12          a = 1" in str(err.value)

--- a/src/fparser/two/utils.py
+++ b/src/fparser/two/utils.py
@@ -325,6 +325,7 @@ class DynamicImport:
             Else_If_Stmt,
             Else_Stmt,
             End_If_Stmt,
+            Label_Do_Stmt,
             Masked_Elsewhere_Stmt,
             Elsewhere_Stmt,
             End_Where_Stmt,
@@ -749,6 +750,21 @@ class BlockBase(Base):
                     # starting from the i+1'th...
                     i += 1
                     continue
+
+                from fparser.two.Fortran2003 import Continue_Stmt, End_Do, End_Do_Stmt, Label_Do_Stmt
+                if (startcls and
+                    isinstance(content[start_idx], Label_Do_Stmt) and
+                    hasattr(obj, "get_end_label") and
+                    content[start_idx].get_start_label() == obj.get_end_label()
+                    and endcls is End_Do and
+                    not isinstance(obj, (End_Do_Stmt, Continue_Stmt))):
+                    if table_name:
+                        SYMBOL_TABLES.exit_scope()
+                    obj.restore_reader(reader)
+                    for obj in reversed(content):
+                        obj.restore_reader(reader)
+                    return None
+
 
                 # We got a match for this class
                 had_match = True

--- a/src/fparser/two/utils.py
+++ b/src/fparser/two/utils.py
@@ -341,7 +341,9 @@ class DynamicImport:
             End_Do_Stmt,
             Label_Do_Stmt,
         )
-        from fparser.two.Fortran2008.label_do_stmt_r816 import Label_Do_Stmt as Label_Do_Stmt_2008
+        from fparser.two.Fortran2008.label_do_stmt_r816 import (
+            Label_Do_Stmt as Label_Do_Stmt_2008,
+        )
 
         from fparser.two import C99Preprocessor
 

--- a/src/fparser/two/utils.py
+++ b/src/fparser/two/utils.py
@@ -361,7 +361,7 @@ class DynamicImport:
         DynamicImport.add_comments_includes_directives = (
             add_comments_includes_directives
         )
-        DynamicImport.Continue_Stmt = Continue_Stmt,
+        DynamicImport.Continue_Stmt = Continue_Stmt
         DynamicImport.End_Do = End_Do
         DynamicImport.End_Do_Stmt = End_Do_Stmt
         DynamicImport.Label_Do_Stmt = Label_Do_Stmt
@@ -776,11 +776,13 @@ class BlockBase(Base):
                 # non-blocked loop). This breaks the exponential behaviour
                 # in case of non-blocked loops (since the parser won't look
                 # ahead till the end of the file).
-                if (startcls is di.Label_Do_Stmt and endcls is di.End_Do and
-                        hasattr(obj, "get_end_label") and
-                        (content[start_idx].get_start_label() ==
-                            obj.get_end_label()) and
-                        not isinstance(obj, (di.End_Do_Stmt, di.Continue_Stmt))):
+                if (
+                    startcls is di.Label_Do_Stmt
+                    and endcls is di.End_Do
+                    and hasattr(obj, "get_end_label")
+                    and (content[start_idx].get_start_label() == obj.get_end_label())
+                    and not isinstance(obj, (di.End_Do_Stmt, di.Continue_Stmt))
+                ):
                     if table_name:
                         SYMBOL_TABLES.exit_scope()
                     # We need to put the just read statement back:

--- a/src/fparser/two/utils.py
+++ b/src/fparser/two/utils.py
@@ -341,6 +341,7 @@ class DynamicImport:
             End_Do_Stmt,
             Label_Do_Stmt,
         )
+        from fparser.two.Fortran2008.label_do_stmt_r816 import Label_Do_Stmt as Label_Do_Stmt_2008
 
         from fparser.two import C99Preprocessor
 
@@ -365,6 +366,7 @@ class DynamicImport:
         DynamicImport.End_Do = End_Do
         DynamicImport.End_Do_Stmt = End_Do_Stmt
         DynamicImport.Label_Do_Stmt = Label_Do_Stmt
+        DynamicImport.Label_Do_Stmt_2008 = Label_Do_Stmt_2008
 
 
 di = DynamicImport()
@@ -777,7 +779,7 @@ class BlockBase(Base):
                 # in case of non-blocked loops (since the parser won't look
                 # ahead till the end of the file).
                 if (
-                    startcls is di.Label_Do_Stmt
+                    startcls in (di.Label_Do_Stmt, di.Label_Do_Stmt_2008)
                     and endcls is di.End_Do
                     and hasattr(obj, "get_end_label")
                     and (content[start_idx].get_start_label() == obj.get_end_label())

--- a/src/fparser/two/utils.py
+++ b/src/fparser/two/utils.py
@@ -325,7 +325,6 @@ class DynamicImport:
             Else_If_Stmt,
             Else_Stmt,
             End_If_Stmt,
-            Label_Do_Stmt,
             Masked_Elsewhere_Stmt,
             Elsewhere_Stmt,
             End_Where_Stmt,
@@ -337,7 +336,12 @@ class DynamicImport:
             Comment,
             Include_Stmt,
             add_comments_includes_directives,
+            Continue_Stmt,
+            End_Do,
+            End_Do_Stmt,
+            Label_Do_Stmt,
         )
+
         from fparser.two import C99Preprocessor
 
         DynamicImport.Else_If_Stmt = Else_If_Stmt
@@ -357,6 +361,10 @@ class DynamicImport:
         DynamicImport.add_comments_includes_directives = (
             add_comments_includes_directives
         )
+        DynamicImport.Continue_Stmt = Continue_Stmt,
+        DynamicImport.End_Do = End_Do
+        DynamicImport.End_Do_Stmt = End_Do_Stmt
+        DynamicImport.Label_Do_Stmt = Label_Do_Stmt
 
 
 di = DynamicImport()
@@ -751,20 +759,37 @@ class BlockBase(Base):
                     i += 1
                     continue
 
-                from fparser.two.Fortran2003 import Continue_Stmt, End_Do, End_Do_Stmt, Label_Do_Stmt
-                if (startcls and
-                    isinstance(content[start_idx], Label_Do_Stmt) and
-                    hasattr(obj, "get_end_label") and
-                    content[start_idx].get_start_label() == obj.get_end_label()
-                    and endcls is End_Do and
-                    not isinstance(obj, (End_Do_Stmt, Continue_Stmt))):
+                # The grammar contains an exponential scaling behaviour for
+                # non-blocked labelled loop statements. The parser will try
+                # to find a match for a blocked do statement, but will ignore
+                # the fact that there is a non-blocking label, e.g.:
+                #     do 10 i=1, 10
+                # 10     a(i) = 1
+                # It will try to find a `10 enddo` or `10 continue` statement,
+                # ignoring the fact that the label 10 indicates that it is not
+                # a blocked loop. Full details in ticket 499.
+                # In order to avoid that, we identify if we are looking for a
+                # labelled loop which is blocked (endcls=End_Do), and have
+                # neither an `End_Do` nor a `Continue`, which has the same
+                # label: in this case we can abort looking (which will then
+                # trigger the caller to test for the next rule, which is a
+                # non-blocked loop). This breaks the exponential behaviour
+                # in case of non-blocked loops (since the parser won't look
+                # ahead till the end of the file).
+                if (startcls is di.Label_Do_Stmt and endcls is di.End_Do and
+                        hasattr(obj, "get_end_label") and
+                        (content[start_idx].get_start_label() ==
+                            obj.get_end_label()) and
+                        not isinstance(obj, (di.End_Do_Stmt, di.Continue_Stmt))):
                     if table_name:
                         SYMBOL_TABLES.exit_scope()
+                    # We need to put the just read statement back:
                     obj.restore_reader(reader)
+                    # ... and then also restore all previously read content
                     for obj in reversed(content):
                         obj.restore_reader(reader)
+                    # ... before we abort.
                     return None
-
 
                 # We got a match for this class
                 had_match = True

--- a/src/fparser/two/utils.py
+++ b/src/fparser/two/utils.py
@@ -783,8 +783,6 @@ class BlockBase(Base):
                     and (content[start_idx].get_start_label() == obj.get_end_label())
                     and not isinstance(obj, (di.End_Do_Stmt, di.Continue_Stmt))
                 ):
-                    if table_name:
-                        SYMBOL_TABLES.exit_scope()
                     # We need to put the just read statement back:
                     obj.restore_reader(reader)
                     # ... and then also restore all previously read content


### PR DESCRIPTION
Fixes the exponential behaviour with number of non-blocked loops in one Fortran unit. This is done by detecting when searching for a blocked loop in e.g.:
```
      do 10 i=1, 10
 10     a(i) = i
```
That the statement with label 10 indicates that there is no matching `10 enddo` (or continue) statement coming, and therefore abooting earlier.

It cuts down parse time for a socrates file that was not parsed in 40 minutes(!!) down to 7 seconds.

Problem: I don't know how to test this patch. During development, the existing tests have flagged some issues I had, so the code is definitely used, and would trigger a failed test if it is really broken. But I don't really know how to test if it triggers as expected (since the function itself would return None without this patch as well ... just later)

Suggestions welcome