### PR TITLE
#503 Remove unnecessary tests for preprocessor directives.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Modifications by (in alphabetical order):
 * P. Vitt, University of Siegen, Germany
 * A. Voysey, UK Met Office
 
+
+27/04/2026 PR #504 for #503. Improve preprocessor directives parsing.
+
+## Release 0.2.2 (19/03/2026) ##
+
 19/03/2026 PR #496. Add support for F2008 unlimited-format-item.
 
 13/03/2026 PR #495 for #494. Fix CI issues with the black formatting check.

--- a/src/fparser/two/utils.py
+++ b/src/fparser/two/utils.py
@@ -712,15 +712,14 @@ class BlockBase(Base):
         if reader.process_directives:
             comments.insert(0, di.Directive)
         classes = subclasses + comments
-        # Preprocessor directives are always valid sub-classes
-        cpp_classes = [
-            getattr(di.C99Preprocessor, cls_name)
-            for cls_name in di.C99Preprocessor.CPP_CLASS_NAMES
-        ]
-        classes += cpp_classes
         if endcls is not None:
             classes += [endcls]
             endcls_all = tuple([endcls] + endcls.subclasses[endcls.__name__])
+        # Preprocessor directives are always valid sub-classes. While
+        # `match_cpp_directive` is a function, it behaves correctly here
+        # returning either None or an instance, so we can just add it to
+        # the classes that will be tested.
+        classes.append(di.C99Preprocessor.match_cpp_directive)
 
         try:
             # Start trying to match the various subclasses, starting from


### PR DESCRIPTION
A small performance optimisation for parsing preprocessor directives. Originally, utils.c would test each cpp directive individually. With this small change, it will first see if the line actually starts with "#" before triggering these tests, which can greatly reduce the number of unnecessary tests.

I also moved matching of preprocessor lines after the test for `endcls` (since it should be more likely for any code to match the expected end directive than a preprocessor directives, which are all in all rather rare), which shaves of another 500 or so tests for one lfric example.