### PR TITLE
Added remaining F2008 intrinsics

### DIFF
--- a/src/fparser/two/Fortran2008/intrinsics_f08.py
+++ b/src/fparser/two/Fortran2008/intrinsics_f08.py
@@ -61,20 +61,82 @@ class Intrinsic_Name(F2003_Intrinsic_Name):
 
     f08_math_intrinsics = {
         "ERF": {"min": 1, "max": 1},
+        "ERFC": {"min": 1, "max": 1},
+        "ERFC_SCALED": {"min": 1, "max": 1},
         "GAMMA": {"min": 1, "max": 1},
+        "HYPOT": {"min": 2, "max": 2},
+        "LOG_GAMMA": {"min": 1, "max": 1},
+        "NORM2": {"min": 1, "max": 2},
+    }
+
+    f08_bitsequence_comparison_intrinsics = {
+        "BGE": {"min": 2, "max": 2},
+        "BGT": {"min": 2, "max": 2},
+        "BLE": {"min": 2, "max": 2},
+        "BLT": {"min": 2, "max": 2},
     }
 
     f08_bitshift_intrinsics = {
+        "DSHIFTL": {"min": 3, "max": 3},
+        "DSHIFTR": {"min": 3, "max": 3},
         "SHIFTL": {"min": 2, "max": 2},
         "SHIFTR": {"min": 2, "max": 2},
         "SHIFTA": {"min": 2, "max": 2},
+        "MERGE_BITS": {"min": 3, "max": 3},
+    }
+
+    f08_counting_bit_intrinsics = {
+        "LEADZ": {"min": 1, "max": 1},
+        "POPCNT": {"min": 1, "max": 1},
+        "POPPAR": {"min": 1, "max": 1},
+        "TRAILZ": {"min": 1, "max": 1},
+    }
+
+    f08_masking_bit_intrinsics = {
+        "MASKL": {"min": 1, "max": 2},
+        "MASKR": {"min": 1, "max": 2},
+    }
+
+    f08_bit_transformation_intrinsics = {
+        "IALL": {"min": 1, "max": 3},
+        "IANY": {"min": 1, "max": 3},
+        "IPARITY": {"min": 1, "max": 3},
+    }
+
+    f08_other_intrinsics = {
+        "STORAGE_SIZE": {"min": 1, "max": 3},
+        "PARITY": {"min": 1, "max": 2},
+        "EXECUTE_COMMAND_LINE": {"min": 1, "max": 5},
+        "FINDLOC": {"min": 2, "max": 6},
+    }
+
+    f08_trig_and_hyper_functions = {
+        "ACOSH": {"min": 1, "max": 1},
+        "ASINH": {"min": 1, "max": 1},
+        "ATANH": {"min": 1, "max": 1},
+    }
+
+    f08_bessel_functions = {
+        "BESSEL_J0": {"min": 1, "max": 1},
+        "BESSEL_J1": {"min": 1, "max": 1},
+        "BESSEL_JN": {"min": 2, "max": 3},
+        "BESSEL_Y0": {"min": 1, "max": 1},
+        "BESSEL_Y1": {"min": 1, "max": 1},
+        "BESSEL_YN": {"min": 2, "max": 3},
     }
 
     # Create the dicts (not inherited from F2003_Intrinsic_Name)
     generic_function_names = {}
     generic_function_names.update(F2003_Intrinsic_Name.generic_function_names)
     generic_function_names.update(f08_math_intrinsics)
+    generic_function_names.update(f08_bitsequence_comparison_intrinsics)
     generic_function_names.update(f08_bitshift_intrinsics)
+    generic_function_names.update(f08_counting_bit_intrinsics)
+    generic_function_names.update(f08_masking_bit_intrinsics)
+    generic_function_names.update(f08_bit_transformation_intrinsics)
+    generic_function_names.update(f08_other_intrinsics)
+    generic_function_names.update(f08_trig_and_hyper_functions)
+    generic_function_names.update(f08_bessel_functions)
 
     specific_function_names = F2003_Intrinsic_Name.specific_function_names
 


### PR DESCRIPTION
This adds all the new F2008 intrinsics. There are some potential extensions to previously existing intrinsics I didn't include, but I wasn't certain enough of those to add them in this PR.

All intrinsics taken from https://wg5-fortran.org/N1851-N1900/N1891.pdf and checked with gcc docs if I was unsure about arguments.